### PR TITLE
Added support to get job runs based on zone/leases

### DIFF
--- a/CI_DailyBuildUpdates.py
+++ b/CI_DailyBuildUpdates.py
@@ -13,16 +13,17 @@ with open('config.json') as config_file:
 
 
 def new_main(config_data):
-    parser = argparse.ArgumentParser(description='Specifies if user needs brief/detailed job information')
+    parser = argparse.ArgumentParser(description='Get the daily buid updates')
     parser.add_argument('--info_type', default='brief', help='specify the job info type')
+    parser.add_argument('--zone', help='specify the lease/zone', type= lambda arg:arg.split(','))
     args = parser.parse_args()
     if args.info_type == "brief":
         summary_list = []
         for ci_name,ci_link in config_data.items():
-            summary_list.extend(monitor.get_brief_job_info(ci_name,ci_link))
+            summary_list.extend(monitor.get_brief_job_info(ci_name,ci_link,zone=args.zone))
         print(tabulate(summary_list, headers='keys', tablefmt="pipe", stralign='left'))
     elif args.info_type == "detailed":
         for ci_name,ci_link in config_data.items():
-            monitor.get_detailed_job_info(ci_name,ci_link)
+            monitor.get_detailed_job_info(ci_name,ci_link,zone=args.zone)
 
 new_main(config_data)

--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -5,6 +5,7 @@ import re
 import json
 from datetime import datetime
 import monitor
+import argparse
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -26,25 +27,45 @@ def get_date_input():
         return None
 
 
-def check_for_node_crashes(job_list):
-    pattern = r'/(\d+)'
-    
+def check_for_node_crashes(job_list, zone):
+    """
+    Check for node crash across all the provided job list
+ 
+    Args:
+        job_list (list): List of jobs which needs to be checked.
+        zone (list): List of the zones/leases that need to checked.
+    """
+    pattern = r'/(\d+)'   
     for url in job_list:
         match = re.search(pattern, url)
         job_id = match.group(1)
+        lease,_ = monitor.get_quota_and_nightly(url)
+        if zone is not None and lease not in zone :
+            continue
         cluster_deploy_status = monitor.cluster_deploy_status(url)
         if cluster_deploy_status == 'SUCCESS':
             node_status = monitor.get_node_status(url)
             print(job_id,node_status)
         monitor.check_node_crash(url)
 
-def get_failed_testcases(spylinks):
+def get_failed_testcases(spylinks, zone):
+    """
+    To get all the failed tescases in all the provided job list
+ 
+    Args:
+        spylinks (list): List of jobs which needs to be checked.
+        zone (list): List of the zones/leases that need to checked.
+    """
+
     pattern = r'/(\d+)'
     j=0
     for spylink in spylinks:
         match = re.search(pattern, spylink)
         job_id = match.group(1)
         job_type,_ = monitor.job_classifier(spylink)
+        lease,_ = monitor.get_quota_and_nightly(spylink)
+        if zone is not None and lease not in zone :
+            continue
         cluster_status=monitor.cluster_deploy_status(spylink)
         if cluster_status == 'SUCCESS' and "4.15" not in spylink:
             j=j+1
@@ -95,6 +116,10 @@ def display_ci_links(config_data):
 
 
 def temp_main(config_data):
+    parser = argparse.ArgumentParser(description='Get the job history')
+    parser.add_argument('--zone', help='specify the lease/zone', type= lambda arg:arg.split(','))
+
+    args = parser.parse_args()
     ci_list = display_ci_links(config_data)
 
 
@@ -116,18 +141,18 @@ def temp_main(config_data):
                     print("-------------------------------------------------------------------------------------------------")
                     print(ci_name)
                     spy_links = monitor.get_jobs_with_date(ci_link,start_date,end_date)
-                    check_for_node_crashes(spy_links)
+                    check_for_node_crashes(spy_links,zone=args.zone)
             
             if option == '2':
                 summary_list = []
                 for ci_name,ci_link in ci_list.items():
-                    summary_list.extend(monitor.get_brief_job_info(ci_name,ci_link,start_date,end_date))
+                    summary_list.extend(monitor.get_brief_job_info(ci_name,ci_link,start_date,end_date,zone=args.zone))
                     monitor.final_job_list = []
                 print(tabulate(summary_list, headers='keys', tablefmt="pipe", stralign='left'))
             
             if option == '3':
                 for ci_name,ci_link in ci_list.items():
-                    monitor.get_detailed_job_info(ci_name,ci_link,start_date,end_date)
+                    monitor.get_detailed_job_info(ci_name,ci_link,start_date,end_date,zone=args.zone)
                     monitor.final_job_list = []
             
             if option == '4':
@@ -135,7 +160,7 @@ def temp_main(config_data):
                     print("-------------------------------------------------------------------------------------------------")
                     print(ci_name)
                     spy_links = monitor.get_jobs_with_date(ci_link,start_date,end_date)
-                    get_failed_testcases(spy_links)
+                    get_failed_testcases(spy_links,zone=args.zone)
                     monitor.final_job_list = []
 
 temp_main(config_data)

--- a/README.md
+++ b/README.md
@@ -27,18 +27,31 @@ Create a virtualenv if required and install required packages using "pip install
 
 1. **CI_DailyBuildUpdate.py:** The CI_DailyBuildUpdates.py script will fetch and display information of the all builds that ran on the CI system for the current day.  
 
-    1. Brief Information: The CI_DailyBuildUpdates.py script when invoked with command line arguement info_type as "brief" it will display Build type, job id, cluster deployment status, Lease and total number of failed testcases.
+    1. Brief Information: The CI_DailyBuildUpdates.py script when invoked with command line argument info_type as "brief" it will display Build type, job id, cluster deployment status, Lease and total number of failed testcases.
 
         ```python3 CI_DailyBuildUpdates.py --info_type brief```
+        
+    2. The CI_DailyBuildUpdates.py script when invoked with command line arguments info_type as "brief" and zone, it will display the builds details in the provided zone.
+        
+        ```python3 CI_DailyBuildUpdates.py --info_type brief --zone syd04```
 
-    2. Detailed Information: The CI_DailyBuildUpdates.py script when invoked with command line arguement info_type as "detailed" it will display the Job id, job link, cluster deployment error message if it occured, Nightly image used, Node status, Checks for Node crash and lists all the failed testcases.  
+    3. Detailed Information: The CI_DailyBuildUpdates.py script when invoked with command line argument info_type as "detailed" it will display the Job id, job link, cluster deployment error message if it occured, Nightly image used, Node status, Checks for Node crash and lists all the failed testcases.  
 
         ```python3 CI_DailyBuildUpdates.py --info_type detailed```
+
+    4. The CI_DailyBuildUpdates.py script when invoked with command line arguments info_type as "detailed" and zone, it will display the builds details in the provided zone.
+
+        ```python3 CI_DailyBuildUpdates.py --info_type detailed --zone syd04```
 
 
 
 2. **CI_JobHistory.py:** The CI_JobHistory.py is a interactive script which allows user to query a specific information from all builds that ran on the CI system within a given date range.  
+    
     ```python3 CI_JobHistory.py```
+
+    1. The CI_JobHistory.py when invoked with command line argument zone, it will get all builds that ran in the particular zone.
+
+    ```python3 CI_JobHistory.py --zone syd04```
 
 
 3. **config.json:** The config.json file will have ci name and ci link in the key value pair where value of ci link will be prow periodic job name.The new CI's can be easily integrated by adding the ci name and ci link in the config.json file.

--- a/monitor.py
+++ b/monitor.py
@@ -426,7 +426,8 @@ def get_next_page_first_build_date(ci_next_page_spylink,end_date):
         print("Failed to get the prowCI response")
         return 'ERROR'
 
-def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None):
+def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None,zone=None):
+    
 
     if start_date is not None and end_date is not None:
         job_list = get_jobs_with_date(prow_ci_link,start_date,end_date)
@@ -449,6 +450,9 @@ def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None):
     for job in job_list:
         match = re.search(pattern_job_id, job)
         job_id = match.group(1)
+        lease, _ = get_quota_and_nightly(job)
+        if zone is not None and lease not in zone :
+            continue
         e2e_test_result = e2e_monitor_result = False
         cluster_status=cluster_deploy_status(job)
         i=i+1
@@ -456,7 +460,7 @@ def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None):
         job_dict["Build"] = prow_ci_name
         job_dict["Prow Job ID"] = job_id
         job_dict["Install Status"] = cluster_status
-        job_dict["Lease"], _ = get_quota_and_nightly(job)
+        job_dict["Lease"]=lease
         
         if cluster_status == 'SUCCESS' and "4.15" not in prow_ci_link:
             deploy_count += 1
@@ -500,23 +504,19 @@ def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None):
         summary_list.append(job_dict)
     return summary_list
 
-def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None):
+def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None,zone=None):
 
     if start_date is not None and end_date is not None:
         job_list = get_jobs_with_date(prow_ci_link,start_date,end_date)
     else:
         job_list = get_jobs(prow_ci_link)
-
-    print("-------------------------------------------------------------------------------------------------")
-
+    print("--------------------------------------------------------------------------------------------------")
     print(prow_ci_name)
 
     if isinstance(job_list,str):
         print(job_list)
         return 1
         
-    if len(job_list) == 0:
-        print ("No job runs on {} ".format(prow_ci_name))
 
     deploy_count = 0
     e2e_count = 0
@@ -524,15 +524,20 @@ def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=Non
 
     pattern_job_id =  r'/(\d+)'
 
+    jobs_to_deleted = []
     for job in job_list:
         match = re.search(pattern_job_id, job)
         job_id = match.group(1)
         e2e_test_result = e2e_monitor_result = False
+        lease, nightly = get_quota_and_nightly(job)
+        if zone is not None and lease not in zone:
+            jobs_to_deleted.append(job)
+            continue
         cluster_status=cluster_deploy_status(job)
         i=i+1
         print(i,".","Job ID: ",job_id)
         print("Job link: https://prow.ci.openshift.org/"+job)
-        lease, nightly = get_quota_and_nightly(job)
+        
         print("Lease Quota-", lease,"\nNightly info-", nightly)
         check_node_crash(job)
         node_status = get_node_status(job)
@@ -593,9 +598,11 @@ def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=Non
 
         print("\n")
         
+    job_list = list(set(job_list) - set(jobs_to_deleted))
     if len(job_list) != 0:
         print ("\n{}/{} deploys succeeded".format(deploy_count, len(job_list)))
         print ("{}/{} e2e tests succeeded".format(e2e_count, len(job_list)))
-        
-
         print("--------------------------------------------------------------------------------------------------")
+    else:
+        print ("No job runs on {} ".format(prow_ci_name))
+    


### PR DESCRIPTION
Added support to get job runs based on zone/leases.

Fix https://github.com/ocp-power-automation/ci-monitoring-automation/issues/8
```
$ python CI_JobHistory.py --zone syd04
1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.11 heavy build
4  4.12 libvirt
5  4.12 to 4.13 upgrade
6  4.12 heavy build
7  4.13 libvirt
8  4.13 powervs
9  4.13 to 4.14 upgrade
10  4.13 heavy build
11  4.14 libvirt
12  4.14 powervs
13  4.14 to 4.15 upgrade
14  4.14 heavy build
15  4.15 libvirt
16  4.15 powervs
17  4.15 heavy build
Select the required ci's serial number with a space 12
Enter Before date (YYYY-MM-DD): 2023-12-01
Enter After date (YYYY-MM-DD): 2023-12-01
Please select one of the option from Job History functionalities: 
1. Node Status
2. Brief Job information
3. Detailed Job information
4. Failed testcases
Enter the option: 1
Checking runs from 2023-12-01 to 2023-12-01
-------------------------------------------------------------------------------------------------
4.14 powervs
1730376393134444544 All nodes are in Ready state
No crash observed


$ python CI_DailyBuildUpdates.py --zone syd04
No job runs on 4.11 to 4.12 upgrade 
No job runs on 4.11 heavy build 
No job runs on 4.12 heavy build 

| Build        |         Prow Job ID | Install Status   | Lease   | Test result        |
|:-------------|--------------------:|:-----------------|:--------|:-------------------|
| 4.13 powervs | 1730557632667717632 | SUCCESS          | syd04   | 1 testcases failed |
| 4.14 powervs | 1730376393134444544 | SUCCESS          | syd04   | 1 testcases failed |
```

python CI_DailyBuildUpdates.py --info_type brief --zone syd04,dal10
/Users/keerthanaarumugam/Documents/Projects/ci-monitoring-automation/env/lib/python3.9/site-packages/urllib3/__init__.py:34: NotOpenSSLWarning: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
  warnings.warn(
No job runs on 4.11 libvirt 
No job runs on 4.11 to 4.12 upgrade 
No job runs on 4.12 libvirt 
No job runs on 4.13 powervs 
No job runs on 4.14 heavy build 
No job runs on 4.15 heavy build 
| Build        |         Prow Job ID | Install Status   | Lease   | Test result        |
|:-------------|--------------------:|:-----------------|:--------|:-------------------|
| 4.14 powervs | 1732278974660218880 | SUCCESS          | syd04   | 2 testcases failed |
| 4.14 powervs | 1732188441891835904 | FAILURE          | syd04   |                    |
| 4.15 powervs | 1732278977160024064 | SUCCESS          | dal10   | PASS               |
| 4.15 powervs | 1732188443141738496 | SUCCESS          | dal10   | 1 testcases failed |