### PR TITLE
Support to check if specifically mentioned testcases are failing in any of builds

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -344,6 +344,35 @@ def print_monitor_testcase_failures(spylink,jobtype):
 
 final_job_list=[]
 
+def check_testcase_failure(spylink,job_type,testcase_name):
+    """
+    Check if a particular testcase is failed in the build.
+
+    Args:
+        spylink (string): Build which needs to be checked.
+        job_type (string): Job type (libvirt or powervs)
+        testcase_name (string): Name of the testcase.
+    Return:
+        return True if testcase failed in this particular build else return False.
+    """
+    failed_tcs = get_failed_e2e_testcases(spylink,job_type)
+    monitor_tcs = get_failed_monitor_testcases(spylink,job_type)
+    if isinstance(failed_tcs,list):
+        for tc in failed_tcs:
+            if testcase_name in tc['Test']['Name']:
+                return True
+    elif isinstance(failed_tcs,str):
+        if testcase_name in failed_tcs:
+            return True
+
+    if isinstance(monitor_tcs,list):
+        for tc in monitor_tcs:
+            if testcase_name in tc['Test']['Name']:
+                return True
+    elif isinstance(monitor_tcs,str):
+        if testcase_name in monitor_tcs:
+            return True
+    return False
 
 #fetches all the job spylinks in the given date range
 


### PR DESCRIPTION
Fix https://github.com/ocp-power-automation/ci-monitoring-automation/issues/11

Added support to check if specifically mentioned testcases are failing in any of builds.

```
$python CI_JobHistory.py
1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.11 heavy build
4  4.12 libvirt
5  4.12 to 4.13 upgrade
6  4.12 heavy build
7  4.13 libvirt
8  4.13 powervs
9  4.13 to 4.14 upgrade
10  4.13 heavy build
11  4.14 libvirt
12  4.14 powervs
13  4.14 to 4.15 upgrade
14  4.14 heavy build
15  4.15 libvirt
16  4.15 powervs
17  4.15 heavy build
Select the required ci's serial number with a space 16
Enter Before date (YYYY-MM-DD): 2023-12-13
Enter After date (YYYY-MM-DD): 2023-12-11
Please select one of the option from Job History functionalities:
1. Node Status
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
Enter the option: 5
Checking runs from 2023-12-11 to 2023-12-13
Enter the testcase names comma seperated: can collect pod-to-service poller pod logs
-------------------------------------------------------------------------------------------------
4.15 powervs
TESTCASE NAME: can collect pod-to-service poller pod logs
1.Job_id: 1734543892038029312
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734543892038029312


2.Job_id: 1734362758805196800
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734362758805196800


3.Job_id: 1734272088526557184
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734272088526557184


--------------------------------------------------------------------------------------------------

$python CI_JobHistory.py
1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.11 heavy build
4  4.12 libvirt
5  4.12 to 4.13 upgrade
6  4.12 heavy build
7  4.13 libvirt
8  4.13 powervs
9  4.13 to 4.14 upgrade
10  4.13 heavy build
11  4.14 libvirt
12  4.14 powervs
13  4.14 to 4.15 upgrade
14  4.14 heavy build
15  4.15 libvirt
16  4.15 powervs
17  4.15 heavy build
Select the required ci's serial number with a space 16
Enter Before date (YYYY-MM-DD): 2023-12-13
Enter After date (YYYY-MM-DD): 2023-12-12
Please select one of the option from Job History functionalities:
1. Node Status
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
Enter the option: 5
Checking runs from 2023-12-12 to 2023-12-13
Enter the testcase names comma seperated: monitor test pod-network-avalibility setup,can collect pod-to-service poller pod logs
-------------------------------------------------------------------------------------------------
4.15 powervs
TESTCASE NAME: monitor test pod-network-avalibility setup
1.Job_id: 1734543892038029312
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734543892038029312


2.Job_id: 1734362758805196800
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734362758805196800


--------------------------------------------------------------------------------------------------


TESTCASE NAME: can collect pod-to-service poller pod logs
1.Job_id: 1734543892038029312
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734543892038029312


2.Job_id: 1734362758805196800
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-per/1734362758805196800


--------------------------------------------------------------------------------------------------
```