### PR TITLE
Fix(#21) Developed function to get all failed testcases from different test suites and store them in a single variable

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -80,13 +80,8 @@ def get_failed_testcases(spylinks, zone):
         if cluster_status == 'SUCCESS' and "4.15" not in spylink:
             j=j+1
             print(str(j)+".",job_id)
-            monitor.print_e2e_testcase_failures(spylink,job_type)
+            monitor.print_all_failed_tc(spylink,job_type)
             print("\n")
-        elif cluster_status == 'SUCCESS' and "4.15" in spylink:
-            j=j+1
-            print(str(j)+".",job_id)
-            monitor.print_e2e_testcase_failures(spylink,job_type)
-            monitor.print_monitor_testcase_failures(spylink,job_type)
     print("--------------------------------------------------------------------------------------------------")
     print("\n")
 


### PR DESCRIPTION
Fix(#21) Developed function to get all failed testcases from different test suites and store them in a single variable.
The function get_all_failed_tc(spylink, jobtype) will get all the failed testcases from all the testsuites and store them in the following format:
{"conformace":[ ], "symptom_detection": [ ], "monitor": [ ]}