### PR TITLE
Added support to print failing testcase with its frequency

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -85,13 +85,30 @@ def get_failed_testcases(spylinks, zone):
         if zone is not None and lease not in zone :
             continue
         cluster_status=monitor.cluster_deploy_status(spylink)
-        if cluster_status == 'SUCCESS' and "4.15" not in spylink:
+        if cluster_status == 'SUCCESS':
             j=j+1
             print(str(j)+".",job_id)
             monitor.print_all_failed_tc(spylink,job_type)
             print("\n")
     print("--------------------------------------------------------------------------------------------------")
     print("\n")
+
+def print_tc_frequency(spylinks, zone, tc_name = None):
+    """
+    To display the testcases failing with its frequency
+
+    Args:
+        spylinks (list): list of builds which needs to be checked.
+        zone (list): List of the zones/leases that need to checked.
+        tc_name (list): list of testcase name.
+
+    """
+
+    frequency = monitor.get_testcase_frequency(spylinks,zone,tc_name)
+    table_data = [(key,value) for key, value in frequency.items()]
+    print(tabulate(table_data, headers = ['Testcase','Frequency'], tablefmt='grid'))
+print("--------------------------------------------------------------------------------------------------")
+print("\n")
 
 def get_testcase_failure(spylinks, zone, tc_name):
     """
@@ -205,6 +222,7 @@ def main():
                 print("3. Detailed Job information")
                 print("4. Failed testcases")
                 print("5. Get builds with testcase failure")
+                print("6. Get testcase failure frequency")
 
                 option = input("Enter the option: ")
             elif JENKINS == "True":
@@ -260,6 +278,22 @@ def main():
                     for tc in tc_list:
                         print("TESTCASE NAME: " + tc)
                         get_testcase_failure(spy_links,zone=args.zone,tc_name=tc)
+                    monitor.final_job_list = []
+
+            if option == '6':
+                  tc_name = input("Enter the testcase names comma seperated (Leave it empty to fetch all tcs frequency): ")
+                  tc_list = None 
+                  if bool(tc_name):
+                      tc_list =  tc_name.split(",") 
+                    
+                  for ci_name,ci_link in ci_list.items():
+                    print("-------------------------------------------------------------------------------------------------")
+                    print(ci_name)
+                    if "sno" in ci_link:
+                        print("Tests execution is not yet supported in SNO")
+                        continue
+                    spy_links = monitor.get_jobs_with_date(ci_link,start_date,end_date)
+                    print_tc_frequency(spy_links,zone=args.zone,tc_name=tc_list)
                     monitor.final_job_list = []
 
 if __name__ == "__main__":

--- a/monitor.py
+++ b/monitor.py
@@ -428,6 +428,44 @@ def get_failed_monitor_testcases(spy_link,job_type):
     else:
         return "Failed to get response from e2e-test directory url"
 
+def get_testcase_frequency(spylinks, zone, tc_name = None):
+    """
+    To get the testcases failing with its frequency
+
+    Args:
+        spylinks (list): list of builds which needs to be checked.
+        zone (list): List of the zones/leases that need to checked.
+        tc_name (list): list of testcase name.
+
+    Returns:
+        dict: Dict with testcase as key and its frequency as value
+
+    """
+    frequency = {}
+    for spylink in spylinks:
+        job_type,_ = job_classifier(spylink)
+        lease,_ = get_quota_and_nightly(spylink)
+        if zone is not None and lease not in zone :
+            continue
+        cluster_status=cluster_deploy_status(spylink)
+        if cluster_status == 'SUCCESS':
+            tc_failures,_ = get_all_failed_tc(spylink,job_type)
+            for _,value in tc_failures.items():
+                if len(value) !=0:
+                    for tc in value:
+                        if tc in frequency:
+                            frequency[tc]+= 1
+                        else:
+                            frequency[tc] = 1
+    sorted_frequency = dict(sorted(frequency.items(),key = lambda item: item[1], reverse=True))
+    frequency = {}
+    if tc_name is not None:
+        for tc in tc_name:
+            if tc in sorted_frequency:
+                frequency[tc] = sorted_frequency[tc]
+        return frequency
+
+    return sorted_frequency
 
 def get_failed_e2e_testcases(spy_link,job_type):
 


### PR DESCRIPTION
Fix https://github.com/ocp-power-automation/ci-monitoring-automation/issues/26


```
$python CI_JobHistory.py
--------------------------------------------------------------------------------------------------


1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.12 libvirt
4  4.12 to 4.13 upgrade
5  4.12 heavy build
6  4.13 libvirt
7  4.13 powervs
8  4.13 to 4.14 upgrade
9  4.13 heavy build
10  4.14 libvirt
11  4.14 powervs
12  4.14 to 4.15 upgrade
13  4.14 heavy build
14  4.15 libvirt
15  4.15 powervs original
16  4.15 powervs siguid
17  4.15 heavy build
18  4.14 MCE
19  4.14 SNO
Select the required ci's serial number with a space 11
Enter Before date (YYYY-MM-DD): 2024-01-10
Enter After date (YYYY-MM-DD): 2024-01-01
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase frequency
Enter the option: 6
Checking runs from 2024-01-01 to 2024-01-10
Enter the testcase names comma seperated: [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel],[sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created  [Suite:openshift/conformance/parallel]
['[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]', '[sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created  [Suite:openshift/conformance/parallel]']
-------------------------------------------------------------------------------------------------
4.14 powervs
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| Testcase                                                                                                                                                                                         |   Frequency |
+==================================================================================================================================================================================================+=============+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel] |           6 |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-network][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall is created  [Suite:openshift/conformance/parallel]                                        |           1 |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+




python CI_JobHistory.py
--------------------------------------------------------------------------------------------------


1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.12 libvirt
4  4.12 to 4.13 upgrade
5  4.12 heavy build
6  4.13 libvirt
7  4.13 powervs
8  4.13 to 4.14 upgrade
9  4.13 heavy build
10  4.14 libvirt
11  4.14 powervs
12  4.14 to 4.15 upgrade
13  4.14 heavy build
14  4.15 libvirt
15  4.15 powervs original
16  4.15 powervs siguid
17  4.15 heavy build
18  4.14 MCE
19  4.14 SNO
Select the required ci's serial number with a space 11
Enter Before date (YYYY-MM-DD): 2024-01-23
Enter After date (YYYY-MM-DD): 2024-01-22
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 6
Checking runs from 2024-01-22 to 2024-01-23
Enter the testcase names comma seperated (Leave it empty to fetch all tcs frequency): 
-------------------------------------------------------------------------------------------------
4.14 powervs
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| Testcase                                                                                                                                                                                                                           |   Frequency |
+====================================================================================================================================================================================================================================+=============+
| [sig-network][Feature:EgressFirewall] egressFirewall should have no impact outside its namespace [Suite:openshift/conformance/parallel]                                                                                            |           2 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to a valid URL if the runbook_url annotation is defined [Suite:openshift/conformance/parallel]                                      |           2 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should support file as subpath [LinuxOnly] [Suite:openshift/conformance/parallel] [Suite:k8s]                                           |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] PersistentVolumes NFS when invoking the Recycle reclaim policy should test that a PV becomes Available and is clean after the PVC is deleted. [Suite:openshift/conformance/parallel] [Suite:k8s]                     |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a valid severity label [Skipped:Disconnected] [Suite:openshift/conformance/parallel]                                                |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] volumes should store data [Suite:openshift/conformance/parallel] [Suite:k8s]                                                                    |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] CSI Mock volume fsgroup policies CSI FSGroupPolicy [LinuxOnly] should modify fsGroup if fsGroupPolicy=File [Suite:openshift/conformance/parallel] [Suite:k8s]                                                        |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] CSI Mock workload info CSI workload information using mock driver should be passed when podInfoOnMount=true [Suite:openshift/conformance/parallel] [Suite:k8s]                                                       |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to an HTTP(S) location if the runbook_url annotation is defined [Suite:openshift/conformance/parallel]                              |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] CSI Mock volume storage capacity CSIStorageCapacity CSIStorageCapacity disabled [Suite:openshift/conformance/parallel] [Suite:k8s]                                                                                   |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Generic Ephemeral-volume (default fs) (immediate-binding)] ephemeral should create read/write inline ephemeral volume [Suite:openshift/conformance/parallel] [Suite:k8s] |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Dynamic PV (default fs)] subPath should support non-existent path [Suite:openshift/conformance/parallel] [Suite:k8s]                                                     |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-storage] In-tree Volumes [Driver: nfs] [Testpattern: Generic Ephemeral-volume (default fs) (late-binding)] ephemeral should support multiple inline ephemeral volumes [Suite:openshift/conformance/parallel] [Suite:k8s]      |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-arch] Managed cluster should set requests but not limits [Suite:openshift/conformance/parallel]                                                                                                                               |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have a runbook_url annotation if the alert is critical [Skipped:Disconnected] [Suite:openshift/conformance/parallel]                     |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
| [sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should have description and summary annotations [Skipped:Disconnected] [Suite:openshift/conformance/parallel]                                   |           1 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------+
