### PR TITLE
Changed code to display output if execution of a test suite is aborted

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 PROW_URL = ""
 PROW_VIEW_URL = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
+final_job_list=[]
 
 def set_prow_url(ci_job_type: str)->str:
     '''
@@ -511,9 +512,11 @@ def get_failed_monitor_testcases(spy_link,job_type):
         job_type (string):  Keyword used to construct url to access the logs of a job.
 
     Returns:
-        list(dict): List of failed monitor testcases.
+        list: List of failed monitor testcases.
+        str: Message if any error occured.
     '''
 
+    monitor_tc_failures = []
     test_log_junit_dir_url = PROW_VIEW_URL + spy_link[8:] + "/artifacts/" + job_type + "/openshift-e2e-libvirt-test/artifacts/junit/"
 
     try:
@@ -529,46 +532,21 @@ def get_failed_monitor_testcases(spy_link,job_type):
                 response_2 = requests.get(test_log_url,verify=False, timeout=15)
                 if response_2.status_code == 200:
                     data = response_2.json()
-                    e2e_failure_list = data['Tests']
-                    return e2e_failure_list
+                    for tc in data['Tests']:
+                        monitor_tc_failures.append(tc["Test"]["Name"])
+                    return monitor_tc_failures, None
                 else:
-                    return "Failed to get response from e2e-test log file url!"
+                    return monitor_tc_failures, "Failed to get response from e2e-test log file url!"
             else:
-                return "Test summary file not found"
+                return monitor_tc_failures, "Test summary file not found"
         else:
-            return "Failed to get response from e2e-test directory url"
+            return monitor_tc_failures, "Failed to get response from e2e-test directory url"
     except requests.Timeout:
-        return "Request timed out"
+        return monitor_tc_failures, "Request timed out"
     except requests.RequestException:
-        return "Error while sending request to url"
+        return monitor_tc_failures, "Error while sending request to url"
     except json.JSONDecodeError as e:
-        return "Failed to parse the data from e2e-test log file!"
-
-def get_failed_monitor_testcases_lv2(spylink, jobtype):
-
-    '''
-    Processes the output received from get_failed_monitor_testcases() function
-
-    Parameter:
-        spylink (string):  SpyglassLink used to generate url to access logs of a job.
-        jobtype (string):  Keyword used to construct url to access logs of a job.
-
-    Returns:
-        list: list of failed monitor testcases.
-        int: Count of total failed testcases
-    '''
-
-    monitor=[]
-    monitor_failed_tc_count = 0
-    monitor_tc_failures = get_failed_monitor_testcases(spylink,jobtype)
-    if isinstance(monitor_tc_failures,list):
-        monitor_failed_tc_count = len(monitor_tc_failures)
-        for tc in monitor_tc_failures:
-            monitor.append(tc["Test"]["Name"])
-    elif isinstance(monitor_tc_failures,str):
-        monitor_failed_tc_count = -5000
-        monitor=[monitor_tc_failures]
-    return monitor,monitor_failed_tc_count
+        return monitor_tc_failures, "Failed to parse the data from e2e-test log file!"
 
 
 def get_failed_monitor_testcases_from_xml(spy_link,job_type):
@@ -581,9 +559,11 @@ def get_failed_monitor_testcases_from_xml(spy_link,job_type):
         job_type (string):  Keyword used to construct url to access logs of a job.
 
     Returns:
-        list(string): List of failed monitor testcases.
+        list: List of failed monitor testcases.
+        str: Message if any error occured.
     '''
 
+    monitor_failed_testcase=[]
     if "mce" in spy_link:
         test_type = "conformance-tests"
     else:
@@ -599,7 +579,6 @@ def get_failed_monitor_testcases_from_xml(spy_link,job_type):
             if test_failure_summary_filename_match is not None:
                 test_failure_summary_filename_str = test_failure_summary_filename_match.group(1)
                 test_log_url=PROW_VIEW_URL + spy_link[8:] + "/artifacts/" + job_type + "/"+ test_type +"/artifacts/junit/" + test_failure_summary_filename_str
-                monitor_failed_testcase=[]
                 response = requests.get(test_log_url,verify=False,timeout=15)
                 if response.status_code == 200:
                     root = ET.fromstring(response.content)
@@ -610,42 +589,18 @@ def get_failed_monitor_testcases_from_xml(spy_link,job_type):
                             prev_testcase = root[idx-1] if idx-1 >= 0 else None
                             if next_testcase is not None and next_testcase.get('name') != current_name and prev_testcase is not None and prev_testcase.get('name') != current_name:
                                 monitor_failed_testcase.append(current_name)
-                    return monitor_failed_testcase
+                    return monitor_failed_testcase, None
             else:
-                return "Monitor test file not found"
+                return monitor_failed_testcase, "Monitor test file not found"
         else:
-            return "Failed to get response from e2e-test directory url" 
+            return monitor_failed_testcase, "Failed to get response from e2e-test directory url" 
     except requests.Timeout:
-        return "Request timed out"
+        return monitor_failed_testcase, "Request timed out"
     except requests.RequestException:
-        return "Error while sending request to url"
+        return monitor_failed_testcase, "Error while sending request to url"
     except ET.ParseError as e:
-        return "Failed to parse junit e2e log file!"
+        return monitor_failed_testcase, "Failed to parse junit e2e log file!"
 
-def get_failed_monitor_testcases_from_xml_lv2(spylink,jobtype):
-
-    '''
-    Processes the output received from get_failed_monitor_testcases_from_xml() function
-
-    Parameter:
-        spylink (string):  SpyglassLink used to generate url to access logs of a job.
-        jobtype (string):  Keyword used to construct url to access logs of a job.
-
-    Returns:
-        list: list of failed monitor testcases.
-        int: Count of total failed testcases
-    '''
-
-    monitor=[]
-    monitor_failed_tc_count = 0
-    monitor_tc_failures = get_failed_monitor_testcases_from_xml(spylink,jobtype)
-    if isinstance(monitor_tc_failures,list):
-        monitor_failed_tc_count = len(monitor_tc_failures)
-        monitor=monitor_tc_failures
-    elif isinstance(monitor_tc_failures,str):
-        monitor_failed_tc_count = -5000
-        monitor=[monitor_tc_failures]
-    return monitor,monitor_failed_tc_count
 
 def get_testcase_frequency(spylinks, zone=None, tc_name = None):
     """
@@ -668,7 +623,7 @@ def get_testcase_frequency(spylinks, zone=None, tc_name = None):
             continue
         cluster_status=cluster_deploy_status(spylink)
         if cluster_status == 'SUCCESS':
-            tc_failures,_ = get_all_failed_tc(spylink,job_type)
+            tc_failures,_,_ = get_all_failed_tc(spylink,job_type)
             for _,value in tc_failures.items():
                 if len(value) !=0:
                     for tc in value:
@@ -696,9 +651,12 @@ def get_failed_e2e_testcases(spy_link,job_type):
         job_type (string):  Keyword used to construct url to access logs of a job.
 
     Returns:
-        list(dict): List of failed conformance testcases.
+        list: List of failed conformance testcases.
+        str: Message if any error occured. 
+
     '''
 
+    conformance_tc_failures=[]
     if "mce" in spy_link:
         test_type = "conformance-tests"
     else:
@@ -717,48 +675,22 @@ def get_failed_e2e_testcases(spy_link,job_type):
                 response_2 = requests.get(test_log_url,verify=False, timeout=15)
                 if response_2.status_code == 200:
                     data = response_2.json()
-                    e2e_failure_list = data['Tests']
-                    return e2e_failure_list
+                    for tc in data['Tests']:
+                        conformance_tc_failures.append(tc["Test"]["Name"])
+                    return conformance_tc_failures, None
                 else:
-                    return "Failed to get response from e2e-test log file url!"
+                    return conformance_tc_failures, "Failed to get response from e2e-test log file url!"
             else:
-                return "Test summary file not found"
+                return conformance_tc_failures, "Test summary file not found"
         else:
-            return "Failed to get response from e2e-test directory url" 
+            return conformance_tc_failures, "Failed to get response from e2e-test directory url" 
     except requests.Timeout:
-        return "Request timed out"
+        return conformance_tc_failures, "Request timed out"
     except requests.RequestException:
-        return "Error while sending request to url"
+        return conformance_tc_failures, "Error while sending request to url"
     except json.JSONDecodeError as e:
-        return "Failed to parse the data from e2e-test log file!"
+        return conformance_tc_failures, "Failed to parse the data from e2e-test log file!"
 
-def get_failed_e2e_testcases_lv2(spylink,jobtype):
-
-    '''
-    Processes the output received from get_failed_e2e_testcases() function
-
-    Parameter:
-        spylink (string):  SpyglassLink used to generate url to access logs of a job.
-        jobtype (string):  Keyword used to construct url to access logs of a job.
-
-    Returns:
-        list: list of failed conformance testcases.
-        int: Count of total failed testcases
-    '''
-
-    conformance=[]
-    conformance_failed_tc_count = 0
-    conformance_tc_failures = get_failed_e2e_testcases(spylink,jobtype)
-
-    if isinstance(conformance_tc_failures,list):
-        conformance_failed_tc_count = len(conformance_tc_failures)
-        for tc in conformance_tc_failures:
-            conformance.append(tc["Test"]["Name"])
-    elif isinstance(conformance_tc_failures,str):
-        conformance_failed_tc_count = -5000
-        conformance=[conformance_tc_failures]
-        
-    return conformance, conformance_failed_tc_count
 
 def get_junit_symptom_detection_testcase_failures(spy_link,job_type):
 
@@ -770,8 +702,11 @@ def get_junit_symptom_detection_testcase_failures(spy_link,job_type):
         job_type (string):  Keyword used to construct url to access logs of a job.
 
     Returns:
-        list(string): List of failed symptom detection testcases.
+        list: List of failed symptom detection testcases.
+        str: Message if any error occured.
     '''
+
+    symptom_detection_failed_testcase = []
 
     if "power" in spy_link:
         job_type=job_type+"/gather-extra"
@@ -788,42 +723,16 @@ def get_junit_symptom_detection_testcase_failures(spy_link,job_type):
                 testcase_name = testcase.get('name')
                 if testcase.find('failure') is not None:
                     symptom_detection_failed_testcase.append(testcase_name)
-            return symptom_detection_failed_testcase
+            return symptom_detection_failed_testcase, None
         else:
-            return 'Error fetching junit symptom detection test results'
+            return symptom_detection_failed_testcase, 'Error fetching junit symptom detection test results'
     except requests.Timeout:
-        return "Request timed out"
+        return symptom_detection_failed_testcase, "Request timed out"
     except requests.RequestException:
-        return "Error while sending request to url"
+        return symptom_detection_failed_testcase, "Error while sending request to url"
     except ET.ParseError as e:
-        return "Failed to parse junit e2e log file!"
+        return symptom_detection_failed_testcase, "Failed to parse symptom detection e2e log file!"
 
-def get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype):
-
-    '''
-    Processes the output received from get_junit_symptom_detection_testcase_failures() function
-
-    Parameter:
-        spylink (string):  SpyglassLink used to generate url to access logs of a job.
-        jobtype (string):  Keyword used to construct url to access logs of a job.
-
-    Returns:
-        list: list of failed symptom detection testcases.
-        int: Count of total failed testcases
-    '''
-
-    symptom_detection=[]
-    symptom_failed_tc_count = 0
-    symptom_detection_tc_failures = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
-
-    if isinstance(symptom_detection_tc_failures,list):
-        symptom_failed_tc_count = len(symptom_detection_tc_failures)
-        symptom_detection = symptom_detection_tc_failures
-    elif isinstance(symptom_detection_tc_failures,str):
-        symptom_failed_tc_count = -5000    
-        symptom_detection=[symptom_detection_tc_failures]
-        
-    return symptom_detection, symptom_failed_tc_count
 
 def get_all_failed_tc(spylink,jobtype):
 
@@ -836,25 +745,37 @@ def get_all_failed_tc(spylink,jobtype):
 
     Returns:
         dict: Dictionary of failed testcases of all testsuites.
+        dict: Error messages encountered while getting test summary files.
         int: Count of total failed testcases
     '''
-
+    conformance_failed_tc_count = 0
     monitor_failed_tc_count = 0
-    conformance,conformance_failed_tc_count = get_failed_e2e_testcases_lv2(spylink,jobtype)
+    symptom_failed_tc_count = 0
+    failed_tc_count = 0
+    monitor_err_obj = None
+    error_object = {}
+    conformance, conformance_error_obj = get_failed_e2e_testcases(spylink,jobtype)
 
-    symptom_detection,symptom_failed_tc_count=get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
+    symptom_detection, symptom_error_obj = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
 
     failed_tc = {"conformance": conformance, "symptom_detection": symptom_detection}
 
-    if "4.15" in spylink and (not "mce" in spylink):
-        monitor,monitor_failed_tc_count=get_failed_monitor_testcases_lv2(spylink,jobtype)
+    conformance_failed_tc_count = len(failed_tc["conformance"])
+    symptom_failed_tc_count = len(failed_tc["symptom_detection"])
+
+    if ("4.15" in spylink or "4.16" in spylink) and (not "mce" in spylink):
+        monitor, monitor_err_obj=get_failed_monitor_testcases(spylink,jobtype)
         failed_tc = {"conformance": conformance, "monitor": monitor, "symptom_detection": symptom_detection}
+        monitor_failed_tc_count = len(failed_tc["monitor"])
     elif "4.14" in spylink or "mce" in spylink:
-        monitor,monitor_failed_tc_count=get_failed_monitor_testcases_from_xml_lv2(spylink,jobtype)
+        monitor, monitor_err_obj = get_failed_monitor_testcases_from_xml(spylink,jobtype)
         failed_tc = {"conformance": conformance, "monitor": monitor, "symptom_detection": symptom_detection}
+        monitor_failed_tc_count = len(failed_tc["monitor"])
     
     failed_tc_count=conformance_failed_tc_count+symptom_failed_tc_count+monitor_failed_tc_count
-    return failed_tc,failed_tc_count
+    error_object = {"conformance": conformance_error_obj, "monitor": monitor_err_obj, "symptom_detection": symptom_error_obj}
+
+    return failed_tc,failed_tc_count,error_object
 
 def check_ts_exe_status(spylink,jobtype):
     '''
@@ -904,10 +825,10 @@ def print_all_failed_tc(spylink,jobtype):
     test_exe_status = check_ts_exe_status(spylink,jobtype)
 
     if test_exe_status == "FAILURE":
-        tc_failures, fail_count = get_all_failed_tc(spylink,jobtype)
-        if fail_count <= 5:
+        tc_failures, fail_count, error_object = get_all_failed_tc(spylink,jobtype)
+        if 0 < fail_count <= 5:
             for key,value in tc_failures.items():
-                if len(value) !=0:
+                if len(value) > 0:
                     print(key,'testcase failures')
                     for tc in value:
                         print(tc)
@@ -915,32 +836,45 @@ def print_all_failed_tc(spylink,jobtype):
                     print('All',key,'testcases passed')
         elif fail_count > 5:
             print(fail_count,"testcases have failed, please refer to the job link for more information")
+
+        if error_object:
+            for key,value in error_object.items():
+                if value:
+                    print(key,'test suite error message: ')
+                    print(value)
         return "FAILURE"
+    
     elif test_exe_status == "SUCCESS":
-        sym,symcount = get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
-        if symcount > 0:
-            print("Symptom Detection Test failures:")
-            for i in sym:
-                print(i)
-            return "FAILURE"
+        sym,sym_error_object = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
+        if not sym_error_object:
+            symcount = len(sym)
+            if symcount > 0:
+                print("Symptom Detection Test failures:")
+                for i in sym:
+                    print(i)
+                return "FAILURE"
+            elif symcount == 0:
+                print("All the Testcases have passed")
+                return "SUCCESS"
         else:
-            print("All the Testcases have passed")
-            return "SUCCESS"
+            print(sym_error_object)
+            return "FAILURE"
     elif test_exe_status == "ABORTED":
-        sym,symcount = get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
-        if symcount > 0:
-            print("Symptom Detection Test failures:")
-            for i in sym:
-                print(i)    
+        sym,sym_error_object = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
+        if not sym_error_object:
+            if symcount > 0:
+                print("Symptom Detection Test failures:")
+                for i in sym:
+                    print(i)
+        else:
+            print(sym_error_object)
+        
         print("Test suite execution has been aborted")
         return "ABORTED"
     else:
         print("ERROR")
         return "ERROR"
         
-            
-
-final_job_list=[]
 
 def check_testcase_failure(spylink,job_type,testcase_name):
     """
@@ -953,7 +887,7 @@ def check_testcase_failure(spylink,job_type,testcase_name):
     Return:
         return True if testcase failed in this particular build else return False.
     """
-    failed_tcs,_ = get_all_failed_tc(spylink,job_type)
+    failed_tcs,_,_ = get_all_failed_tc(spylink,job_type)
 
     for _,values in failed_tcs.items():
         if testcase_name in values:
@@ -1138,12 +1072,13 @@ def get_brief_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=None,z
         job_dict["Lease"]=lease
         if cluster_status == 'SUCCESS' and "sno" not in prow_ci_link:
             job_type,_ = job_classifier(job)
-            _, e2e_test_result = get_all_failed_tc(job,job_type)
-            if e2e_test_result == 0:
-                job_dict["Test result"] = "PASS"   
-            elif e2e_test_result > 0:
-                job_dict["Test result"] = str(e2e_test_result) + " testcases failed"   
-            elif e2e_test_result < 0:
+            _, e2e_fail_test_count, error_object = get_all_failed_tc(job,job_type)
+            if all(value == None for value in error_object.values()):
+                if e2e_fail_test_count == 0:
+                    job_dict["Test result"] = "PASS"   
+                elif e2e_fail_test_count > 0:
+                    job_dict["Test result"] = str(e2e_fail_test_count) + " testcases failed"   
+            else:
                 job_dict["Test result"] = "Failed to get Test summary"
         summary_list.append(job_dict)
     return summary_list

--- a/monitor.py
+++ b/monitor.py
@@ -544,6 +544,32 @@ def get_failed_monitor_testcases(spy_link,job_type):
     except json.JSONDecodeError as e:
         return "Failed to parse the data from e2e-test log file!"
 
+def get_failed_monitor_testcases_lv2(spylink, jobtype):
+
+    '''
+    Processes the output received from get_failed_monitor_testcases() function
+
+    Parameter:
+        spylink (string):  SpyglassLink used to generate url to access logs of a job.
+        jobtype (string):  Keyword used to construct url to access logs of a job.
+
+    Returns:
+        list: list of failed monitor testcases.
+        int: Count of total failed testcases
+    '''
+
+    monitor=[]
+    monitor_failed_tc_count = 0
+    monitor_tc_failures = get_failed_monitor_testcases(spylink,jobtype)
+    if isinstance(monitor_tc_failures,list):
+        monitor_failed_tc_count = len(monitor_tc_failures)
+        for tc in monitor_tc_failures:
+            monitor.append(tc["Test"]["Name"])
+    elif isinstance(monitor_tc_failures,str):
+        monitor_failed_tc_count = -5000
+        monitor=[monitor_tc_failures]
+    return monitor,monitor_failed_tc_count
+
 
 def get_failed_monitor_testcases_from_xml(spy_link,job_type):
 
@@ -596,7 +622,30 @@ def get_failed_monitor_testcases_from_xml(spy_link,job_type):
     except ET.ParseError as e:
         return "Failed to parse junit e2e log file!"
 
+def get_failed_monitor_testcases_from_xml_lv2(spylink,jobtype):
 
+    '''
+    Processes the output received from get_failed_monitor_testcases_from_xml() function
+
+    Parameter:
+        spylink (string):  SpyglassLink used to generate url to access logs of a job.
+        jobtype (string):  Keyword used to construct url to access logs of a job.
+
+    Returns:
+        list: list of failed monitor testcases.
+        int: Count of total failed testcases
+    '''
+
+    monitor=[]
+    monitor_failed_tc_count = 0
+    monitor_tc_failures = get_failed_monitor_testcases_from_xml(spylink,jobtype)
+    if isinstance(monitor_tc_failures,list):
+        monitor_failed_tc_count = len(monitor_tc_failures)
+        monitor=monitor_tc_failures
+    elif isinstance(monitor_tc_failures,str):
+        monitor_failed_tc_count = -5000
+        monitor=[monitor_tc_failures]
+    return monitor,monitor_failed_tc_count
 
 def get_testcase_frequency(spylinks, zone=None, tc_name = None):
     """
@@ -683,6 +732,34 @@ def get_failed_e2e_testcases(spy_link,job_type):
     except json.JSONDecodeError as e:
         return "Failed to parse the data from e2e-test log file!"
 
+def get_failed_e2e_testcases_lv2(spylink,jobtype):
+
+    '''
+    Processes the output received from get_failed_e2e_testcases() function
+
+    Parameter:
+        spylink (string):  SpyglassLink used to generate url to access logs of a job.
+        jobtype (string):  Keyword used to construct url to access logs of a job.
+
+    Returns:
+        list: list of failed conformance testcases.
+        int: Count of total failed testcases
+    '''
+
+    conformance=[]
+    conformance_failed_tc_count = 0
+    conformance_tc_failures = get_failed_e2e_testcases(spylink,jobtype)
+
+    if isinstance(conformance_tc_failures,list):
+        conformance_failed_tc_count = len(conformance_tc_failures)
+        for tc in conformance_tc_failures:
+            conformance.append(tc["Test"]["Name"])
+    elif isinstance(conformance_tc_failures,str):
+        conformance_failed_tc_count = -5000
+        conformance=[conformance_tc_failures]
+        
+    return conformance, conformance_failed_tc_count
+
 def get_junit_symptom_detection_testcase_failures(spy_link,job_type):
 
     '''
@@ -721,6 +798,32 @@ def get_junit_symptom_detection_testcase_failures(spy_link,job_type):
     except ET.ParseError as e:
         return "Failed to parse junit e2e log file!"
 
+def get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype):
+
+    '''
+    Processes the output received from get_junit_symptom_detection_testcase_failures() function
+
+    Parameter:
+        spylink (string):  SpyglassLink used to generate url to access logs of a job.
+        jobtype (string):  Keyword used to construct url to access logs of a job.
+
+    Returns:
+        list: list of failed symptom detection testcases.
+        int: Count of total failed testcases
+    '''
+
+    symptom_detection=[]
+    symptom_failed_tc_count = 0
+    symptom_detection_tc_failures = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
+
+    if isinstance(symptom_detection_tc_failures,list):
+        symptom_failed_tc_count = len(symptom_detection_tc_failures)
+        symptom_detection = symptom_detection_tc_failures
+    elif isinstance(symptom_detection_tc_failures,str):
+        symptom_failed_tc_count = -5000    
+        symptom_detection=[symptom_detection_tc_failures]
+        
+    return symptom_detection, symptom_failed_tc_count
 
 def get_all_failed_tc(spylink,jobtype):
 
@@ -736,55 +839,53 @@ def get_all_failed_tc(spylink,jobtype):
         int: Count of total failed testcases
     '''
 
-    conformance_failed_tc_count=0
-    monitor_failed_tc_count=0
-    symptom_failed_tc_count=0
+    monitor_failed_tc_count = 0
+    conformance,conformance_failed_tc_count = get_failed_e2e_testcases_lv2(spylink,jobtype)
 
-    conformance_tc_failures = get_failed_e2e_testcases(spylink,jobtype)
-    conformance=[]
-    if isinstance(conformance_tc_failures,list):
-        conformance_failed_tc_count = len(conformance_tc_failures)
-        for tc in conformance_tc_failures:
-            conformance.append(tc["Test"]["Name"])
-    elif isinstance(conformance_tc_failures,str):
-        conformance_failed_tc_count = -5000
-        conformance=[conformance_tc_failures]
-
-    symptom_detection_tc_failures = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
-    symptom_detection=[]
-    if isinstance(symptom_detection_tc_failures,list):
-        symptom_failed_tc_count = len(symptom_detection_tc_failures)
-        symptom_detection = symptom_detection_tc_failures
-    elif isinstance(symptom_detection_tc_failures,str):    
-        symptom_failed_tc_count = -5000
-        symptom_detection=[symptom_detection_tc_failures]
+    symptom_detection,symptom_failed_tc_count=get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
 
     failed_tc = {"conformance": conformance, "symptom_detection": symptom_detection}
 
-    if ("4.15" in spylink or "4.16" in spylink) and (not "mce" in spylink):
-        monitor_tc_failures = get_failed_monitor_testcases(spylink,jobtype)
-        monitor=[]
-        if isinstance(monitor_tc_failures,list):
-            monitor_failed_tc_count = len(monitor_tc_failures)
-            for tc in monitor_tc_failures:
-                monitor.append(tc["Test"]["Name"])
-        elif isinstance(monitor_tc_failures,str):
-            monitor_failed_tc_count = -5000
-            monitor=[monitor_tc_failures]
+    if "4.15" in spylink and (not "mce" in spylink):
+        monitor,monitor_failed_tc_count=get_failed_monitor_testcases_lv2(spylink,jobtype)
         failed_tc = {"conformance": conformance, "monitor": monitor, "symptom_detection": symptom_detection}
     elif "4.14" in spylink or "mce" in spylink:
-        monitor=[]
-        monitor_tc_failures = get_failed_monitor_testcases_from_xml(spylink,jobtype)
-        if isinstance(monitor_tc_failures,list):
-            monitor_failed_tc_count = len(monitor_tc_failures)
-            monitor=monitor_tc_failures
-        elif isinstance(monitor_tc_failures,str):
-            monitor_failed_tc_count = -5000
-            monitor=[monitor_tc_failures]
+        monitor,monitor_failed_tc_count=get_failed_monitor_testcases_from_xml_lv2(spylink,jobtype)
         failed_tc = {"conformance": conformance, "monitor": monitor, "symptom_detection": symptom_detection}
     
     failed_tc_count=conformance_failed_tc_count+symptom_failed_tc_count+monitor_failed_tc_count
     return failed_tc,failed_tc_count
+
+def check_ts_exe_status(spylink,jobtype):
+    '''
+    Checks conformance Test suite execution status.
+
+    Parameter:
+        spylink (string):  SpyglassLink used to generate url to access logs of a job.
+        jobtype (string):  Keyword used to construct url to access logs of a job.
+
+    Returns:
+        str: Status of test suite execution
+    '''
+
+    if "mce" in spylink:
+        test_type = "conformance-tests"
+    else:
+        test_type = "openshift-e2e-libvirt-test"
+    test_exe_status_url = PROW_VIEW_URL + spylink[8:] + "/artifacts/" + jobtype + "/" + test_type + "/finished.json"
+    try:
+        response = requests.get(test_exe_status_url, verify=False, timeout=15)
+        if response.status_code == 200:
+            cluster_status = json.loads(response.text)
+            return cluster_status["result"]
+        else:
+            return "Error"
+    except requests.Timeout:
+        return "Request timed out"
+    except requests.RequestException:
+        return "Error while sending request to url"
+    except json.JSONDecodeError as e:
+        return 'ERROR'
 
 
 def print_all_failed_tc(spylink,jobtype):
@@ -797,18 +898,46 @@ def print_all_failed_tc(spylink,jobtype):
         jobtype (string):  Keyword used to construct url to access logs of a job.
 
     Returns:
-        int: Count of total failed testcases
+        str: Status of test suite execution
     '''
 
-    tc_failures,failed_tc_count = get_all_failed_tc(spylink,jobtype)
-    for key,value in tc_failures.items():
-        if len(value) !=0:
-            print(key,'testcase failures')
-            for tc in value:
-                print(tc)
-        elif len(value) == 0:
-            print('All',key,'testcases passed')
-    return failed_tc_count
+    test_exe_status = check_ts_exe_status(spylink,jobtype)
+
+    if test_exe_status == "FAILURE":
+        tc_failures, fail_count = get_all_failed_tc(spylink,jobtype)
+        if fail_count <= 5:
+            for key,value in tc_failures.items():
+                if len(value) !=0:
+                    print(key,'testcase failures')
+                    for tc in value:
+                        print(tc)
+                elif len(value) == 0:
+                    print('All',key,'testcases passed')
+        elif fail_count > 5:
+            print(fail_count,"testcases have failed, please refer to the job link for more information")
+        return "FAILURE"
+    elif test_exe_status == "SUCCESS":
+        sym,symcount = get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
+        if symcount > 0:
+            print("Symptom Detection Test failures:")
+            for i in sym:
+                print(i)
+            return "FAILURE"
+        else:
+            print("All the Testcases have passed")
+            return "SUCCESS"
+    elif test_exe_status == "ABORTED":
+        sym,symcount = get_junit_symptom_detection_testcase_failures_lv2(spylink,jobtype)
+        if symcount > 0:
+            print("Symptom Detection Test failures:")
+            for i in sym:
+                print(i)    
+        print("Test suite execution has been aborted")
+        return "ABORTED"
+    else:
+        print("ERROR")
+        return "ERROR"
+        
             
 
 final_job_list=[]
@@ -1061,8 +1190,7 @@ def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=Non
             jobs_to_deleted.append(job)
             continue
         i=i+1
-        print(i,".","Job ID: ",job_id)
-        print("Job link: https://prow.ci.openshift.org/"+job)
+        print(i,"Job link: https://prow.ci.openshift.org/"+job)
         print("Nightly info-", nightly)
         cluster_status=cluster_deploy_status(job)
         if "sno" not in job:
@@ -1075,13 +1203,12 @@ def get_detailed_job_info(prow_ci_name,prow_ci_link,start_date=None,end_date=Non
             deploy_count += 1
             if "sno" not in prow_ci_link:
                 job_type,_ = job_classifier(job)
-                failed_tc_count=print_all_failed_tc(job,job_type)
-                if failed_tc_count==0:
+                tc_exe_status=print_all_failed_tc(job,job_type)
+                if tc_exe_status=="SUCCESS":
                     e2e_count=e2e_count+1
 
         elif cluster_status == 'FAILURE':
-                print("Cluster Creation Failed")
-                cluster_creation_error_analysis(job)
+            print("Cluster Creation Failed")
 
         elif cluster_status == 'ERROR':
             print('Unable to get cluster status please check prowCI UI ')

--- a/tracker.py
+++ b/tracker.py
@@ -15,11 +15,12 @@ def filter_latest_ci_lv1(config_data,n_build):
             cluster_status=monitor.cluster_deploy_status(job)
             job_type,_=monitor.job_classifier(job)
             if cluster_status == 'SUCCESS':
-                _ , failed_tc_count = monitor.get_all_failed_tc(job,job_type)
-                if failed_tc_count < 20 and failed_tc_count > 0:
-                    tc_failure_jobs.append(job)
-                elif failed_tc_count > 20:
-                    huge_tc_failure_jobs.append(job)
+                _ , failed_tc_count, error_object = monitor.get_all_failed_tc(job,job_type)
+                if all(value == None for value in error_object.values()):
+                    if failed_tc_count < 20 and failed_tc_count > 0:
+                        tc_failure_jobs.append(job)
+                    elif failed_tc_count > 20:
+                        huge_tc_failure_jobs.append(job)
             final_tc_failure_jobs = [tc_failure_jobs,huge_tc_failure_jobs]
         updated_ci_dict[ci_name] = final_tc_failure_jobs
     return updated_ci_dict


### PR DESCRIPTION
Fix(#44)
Modularized get_all_failed_tc() function

Earlier we used to directly check the test summary files to get the failed testcases but in event of test suite execution abort it would make the test summary file as empty which would lead us to believe that no test cases have failed, so I have developed this check_ts_exe_status() which will find finished.json file and check the status of test suite execution, if the result was "Failure" it will return "Failure" to print_all_failed_tc() function which will print all the failed testcase by calling get_all_failed_tc() function, if check_ts_exe_status() function returned either "SUCCESS" or "ABORTED", the print_all_failed_tc() function would check if any symptom detection testcases have failed by calling get_junit_symptom_detection_testcase_failures_lv2() function if yes, it will print the failed symptom detection testcases and then print success and aborted messages accordingly.