### PR TITLE
Added support for 4.16 Jobs

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -761,7 +761,7 @@ def get_all_failed_tc(spylink,jobtype):
 
     failed_tc = {"conformance": conformance, "symptom_detection": symptom_detection}
 
-    if "4.15" in spylink and (not "mce" in spylink):
+    if ("4.15" in spylink or "4.16" in spylink) and (not "mce" in spylink):
         monitor_tc_failures = get_failed_monitor_testcases(spylink,jobtype)
         monitor=[]
         if isinstance(monitor_tc_failures,list):

--- a/p_periodic.json
+++ b/p_periodic.json
@@ -16,6 +16,10 @@
     "4.15 powervs original": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-original",
     "4.15 powervs siguid": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-siguid",
     "4.15 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
+    "4.15 to 4.16 upgrade": "periodic-ci-openshift-multiarch-master-nightly-4.16-upgrade-from-nightly-4.15-ocp-ovn-remote-libvirt-ppc64le",
+    "4.16 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le",
+    "4.16 powervs": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-ppc64le-powervs-original",
+    "4.16 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
     "4.14 MCE": "periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-mce-power-conformance",
     "4.15 MCE": "periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-mce-power-conformance",
     "4.14 SNO": "periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-e2e-sno-power"


### PR DESCRIPTION
```
(env)  python CI_DailyBuildUpdates.py 

| Build                 |         Prow Job ID | Install Status   | Lease                             | Test result        |
|:----------------------|--------------------:|:-----------------|:----------------------------------|:-------------------|
| 4.12 libvirt          | 1765905355830726656 | ERROR            | Failed to fetch lease information |                    |
| 4.12 to 4.13 upgrade  | 1766011040052547584 | SUCCESS          | libvirt-ppc64le-2-1               | PASS               |
| 4.13 libvirt          | 1765920448937201664 | SUCCESS          | libvirt-ppc64le-0-1               | PASS               |
| 4.13 to 4.14 upgrade  | 1766026137265246208 | SUCCESS          | libvirt-ppc64le-0-2               | PASS               |
| 4.13 heavy build      | 1765980838178066432 | SUCCESS          | libvirt-ppc64le-0-0               | PASS               |
| 4.14 libvirt          | 1765935550662971392 | SUCCESS          | libvirt-ppc64le-2-2               | PASS               |
| 4.14 powervs          | 1765980839859982336 | FAILURE          | syd04                             |                    |
| 4.14 powervs          | 1765890306839941120 | FAILURE          | syd05                             |                    |
| 4.14 to 4.15 upgrade  | 1766041235975311360 | SUCCESS          | libvirt-ppc64le-2-0               | PASS               |
| 4.14 heavy build      | 1765995934530932736 | FAILURE          | libvirt-ppc64le-2-3               |                    |
| 4.15 libvirt          | 1765950667781836800 | SUCCESS          | libvirt-ppc64le-1-2               | PASS               |
| 4.15 powervs original | 1765980840694648832 | SUCCESS          | dal10                             | 1 testcases failed |
| 4.15 powervs original | 1765890308521857024 | ERROR            | Failed to fetch lease information |                    |
| 4.16 libvirt          | 1765965746124361728 | SUCCESS          | libvirt-ppc64le-1-0               | 1 testcases failed |
| 4.16 powervs          | 1765980841546092544 | SUCCESS          | wdc06                             | 2 testcases failed |
| 4.16 powervs          | 1765890309784342528 | SUCCESS          | wdc06                             | 1 testcases failed |
| 4.14 MCE              | 1765950649322704896 | SUCCESS          | us-west-2--aws-quota-slice-05     | PASS               |
| 4.15 MCE              | 1765980836508733440 | SUCCESS          | us-west-2--aws-quota-slice-17     | PASS               |
| 4.14 SNO              | 1765950667370795008 | FAILURE          |                                   |                    |
```