### PR TITLE
Added symcount variable to get count of failed testcases

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -4,4 +4,4 @@ selected_ci = __CI__
 before_date = __BDATE__
 after_date = __ADATE__
 query_option = __QP__
-tc_name = 
+tc_name = __TC__

--- a/monitor.py
+++ b/monitor.py
@@ -828,10 +828,12 @@ def print_all_failed_tc(spylink,jobtype):
         tc_failures, fail_count, error_object = get_all_failed_tc(spylink,jobtype)
         if 0 < fail_count <= 5:
             for key,value in tc_failures.items():
+                i = 1
                 if len(value) > 0:
-                    print(key,'testcase failures')
+                    print('Failed',key,'testcases: ')
                     for tc in value:
-                        print(tc)
+                        print(str(i)+'.',tc)
+                        i=i+1
                 elif len(value) == 0:
                     print('All',key,'testcases passed')
         elif fail_count > 5:
@@ -862,6 +864,7 @@ def print_all_failed_tc(spylink,jobtype):
     elif test_exe_status == "ABORTED":
         sym,sym_error_object = get_junit_symptom_detection_testcase_failures(spylink,jobtype)
         if not sym_error_object:
+            symcount = len(sym)
             if symcount > 0:
                 print("Symptom Detection Test failures:")
                 for i in sym:


### PR DESCRIPTION
Added symcount variable to get count of failed symptom detection testcases when conformance test suite execution is aborted
Initialized tc_name with __TC__ in config.ini file 