### PR TITLE
Added support to get all CIs JobHistory

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -168,6 +168,9 @@ def display_ci_links(config_data):
             j=j+1
             ci_name_list.append(ci_name)
             print(j,'',ci_name)
+        j=j+1
+        print(j, " All")
+
 
         option = input("Select the required ci's serial number with a space ")
 
@@ -179,8 +182,11 @@ def display_ci_links(config_data):
                 ci_to_int = int(ci)
                 if 0 < ci_to_int <= len(config_data):
                     options_int_list.append(ci_to_int)
+                elif ci_to_int == len(config_data) + 1:
+                    for j in range (1, len(config_data)+1):
+                        options_int_list.append(j)
                 else:
-                    return_value = "Enter the options in range of 1 to " + str(len(config_data))
+                    return_value = "Enter the options in range of 1 to " + str(len(config_data)+1)
                     print(return_value)
                     return "ERROR"
             except ValueError:
@@ -189,9 +195,13 @@ def display_ci_links(config_data):
         for ci_name in config_data.keys():
             j=j+1
             ci_name_list.append(ci_name)
+   
 
         selected_ci = config_vars.get('Settings', 'selected_ci')
         options_int_list = [int(value) for value in selected_ci.split(',')]
+        if len(ci_name_list)+1 in options_int_list:
+            options_int_list = [x for x in range(1, len(ci_name_list)+1)]
+
 
     for i in options_int_list:
         config_temp_data = {ci_name_list[i-1]: config_data[ci_name_list[i-1]]}


### PR DESCRIPTION
Fix for https://github.com/ocp-power-automation/ci-monitoring-automation/issues/54

Added a last entry "All" in the Ci list as below.

1. Power Jobs
```
python CI_JobHistory.py
1  4.11 libvirt
2  4.11 to 4.12 upgrade
3  4.12 libvirt
4  4.12 to 4.13 upgrade
5  4.12 heavy build
6  4.13 libvirt
7  4.13 powervs
8  4.13 to 4.14 upgrade
9  4.13 heavy build
10  4.14 libvirt
11  4.14 powervs
12  4.14 to 4.15 upgrade
13  4.14 heavy build
14  4.15 libvirt
15  4.15 powervs original
16  4.15 powervs siguid
17  4.15 heavy build
18  4.15 to 4.16 upgrade
19  4.16 libvirt
20  4.16 powervs
21  4.16 heavy build
22  4.14 MCE
23  4.15 MCE
24  4.14 SNO
25  All
Select the required ci's serial number with a space 25
Enter Before date (YYYY-MM-DD): 2024-04-10
Enter After date (YYYY-MM-DD): 2024-04-10
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 2
Checking runs from 2024-04-10 to 2024-04-10
| Build                 |         Prow Job ID | Install Status           | Lease                             | Test result        |
|:----------------------|--------------------:|:-------------------------|:----------------------------------|:-------------------|
| 4.12 to 4.13 upgrade  | 1778151093323173888 | SUCCESS                  | libvirt-ppc64le-2-3               | PASS               |
| 4.12 to 4.13 upgrade  | 1777969925210509312 | SUCCESS                  | libvirt-ppc64le-0-0               | 2 testcases failed |
| 4.12 heavy build      | 1777864424221052928 | SUCCESS                  | libvirt-ppc64le-0-2               | PASS               |
| 4.13 libvirt          | 1778060512265768960 | SUCCESS                  | libvirt-ppc64le-0-2               | 1 testcases failed |
| 4.13 libvirt          | 1777879492757295104 | SUCCESS                  | libvirt-ppc64le-2-1               | PASS               |
| 4.13 to 4.14 upgrade  | 1778166188866539520 | SUCCESS                  | libvirt-ppc64le-1-2               | PASS               |
| 4.13 to 4.14 upgrade  | 1777984995009236992 | SUCCESS                  | libvirt-ppc64le-2-0               | 2 testcases failed |
| 4.13 heavy build      | 1777939724497850368 | FAILURE                  | libvirt-ppc64le-2-3               |                    |
| 4.14 libvirt          | 1777894431437885440 | SUCCESS                  | libvirt-ppc64le-2-2               | PASS               |
| 4.14 powervs          | 1777939730369875968 | FAILURE                  | syd05                             |                    |
| 4.14 powervs          | 1777849450257977344 | SUCCESS                  | syd04                             | 1 testcases failed |
| 4.14 to 4.15 upgrade  | 1778181293490573312 | SUCCESS                  | libvirt-ppc64le-0-1               | PASS               |
| 4.14 to 4.15 upgrade  | 1778000096164581376 | SUCCESS                  | libvirt-ppc64le-1-1               | PASS               |
| 4.14 heavy build      | 1777954802085400576 | SUCCESS                  | libvirt-ppc64le-0-1               | 3 testcases failed |
| 4.15 libvirt          | 1777909577048657920 | SUCCESS                  | libvirt-ppc64le-1-0               | PASS               |
| 4.15 powervs original | 1778120908297211904 | SUCCESS                  | dal10                             | PASS               |
| 4.15 powervs original | 1777939732907429888 | FAILURE                  | dal10                             |                    |
| 4.15 powervs original | 1777849453592449024 | SUCCESS                  | dal10                             | 1 testcases failed |
| 4.15 to 4.16 upgrade  | 1778196404770967552 | SUCCESS                  | libvirt-ppc64le-0-0               | PASS               |
| 4.15 to 4.16 upgrade  | 1778015205922443264 | SUCCESS                  | Failed to fetch lease information |                    |
| 4.16 libvirt          | 1777924626320461824 | SUCCESS                  | libvirt-ppc64le-1-2               | PASS               |
| 4.16 powervs          | 1778120910838960128 | SUCCESS                  | wdc06                             | 1 testcases failed |
| 4.16 powervs          | 1777939735398846464 | ERROR                    | Failed to fetch lease information |                    |
| 4.16 powervs          | 1777849456155168768 | ERROR                    | Failed to fetch lease information |                    |
| 4.14 MCE              | 1777909538456866816 | MCE-INSTALL SUCCESS      | us-east-1--aws-quota-slice-40     |                    |
|                       |                     | MCE-POWER-CREATE FAILURE |                                   |                    |
| 4.15 MCE              | 1777939710237216768 | SUCCESS                  | us-east-1--aws-quota-slice-19     | PASS               |
| 4.14 SNO              | 1777909575366742016 | FAILURE                  |                                   |                    |

```` 

2. Z Jobs

```
python CI_JobHistory.py --job_type z
1  4.11 libvirt
2  4.11 heavy build
3  4.12 libvirt
4  4.12 heavy build
5  4.13 libvirt
6  4.13 heavy build
7  4.14 libvirt
8  4.14 heavy build
9  4.15 libvirt
10  4.15 heavy build
11  All
Select the required ci's serial number with a space 11
Enter Before date (YYYY-MM-DD): 2024-04-10
Enter After date (YYYY-MM-DD): 2024-04-10
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 2
Checking runs from 2024-04-10 to 2024-04-10
| Build            |         Prow Job ID | Install Status   | Lease             | Test result                |
|:-----------------|--------------------:|:-----------------|:------------------|:---------------------------|
| 4.11 heavy build | 1777864425894580224 | SUCCESS          | libvirt-s390x-6-1 | PASS                       |
| 4.12 heavy build | 1777864425894580224 | SUCCESS          | libvirt-s390x-6-1 | PASS                       |
| 4.13 libvirt     | 1778060515625406464 | SUCCESS          | libvirt-s390x-4-1 | PASS                       |
| 4.13 libvirt     | 1777879494439211008 | SUCCESS          | libvirt-s390x-4-1 | PASS                       |
| 4.13 heavy build | 1777939727844904960 | SUCCESS          | libvirt-s390x-6-0 | Failed to get Test summary |
| 4.14 libvirt     | 1777894433115607040 | SUCCESS          | libvirt-s390x-5-0 | 2 testcases failed         |
| 4.14 heavy build | 1777954804597788672 | SUCCESS          | libvirt-s390x-5-1 | PASS                       |
| 4.15 libvirt     | 1777909579561046016 | SUCCESS          | libvirt-s390x-2-1 | 78 testcases failed        |

```
Jenkin job link:
http://molly.aus.stglabs.ibm.com:8090/job/Prow/job/custom-prow-prod-ci-job-status1/10/console