### PR TITLE
Added changes to check node details of compact run

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -169,22 +169,14 @@ def display_ci_links(config_data):
             ci_name_list.append(ci_name)
             print(j,'',ci_name)
         j=j+1
-        print(j, " All")
-
-
+        print(j, " All the above")
         option = input("Select the required ci's serial number with a space ")
-
         selected_options = option.split()
-
-   
         for ci in selected_options:
             try:
                 ci_to_int = int(ci)
-                if 0 < ci_to_int <= len(config_data):
+                if 0 < ci_to_int <= len(config_data)+1:
                     options_int_list.append(ci_to_int)
-                elif ci_to_int == len(config_data) + 1:
-                    for j in range (1, len(config_data)+1):
-                        options_int_list.append(j)
                 else:
                     return_value = "Enter the options in range of 1 to " + str(len(config_data)+1)
                     print(return_value)
@@ -199,15 +191,15 @@ def display_ci_links(config_data):
 
         selected_ci = config_vars.get('Settings', 'selected_ci')
         options_int_list = [int(value) for value in selected_ci.split(',')]
-        if len(ci_name_list)+1 in options_int_list:
-            options_int_list = [x for x in range(1, len(ci_name_list)+1)]
 
+    if len(config_data)+1 in options_int_list:
+        return config_data
 
     for i in options_int_list:
         config_temp_data = {ci_name_list[i-1]: config_data[ci_name_list[i-1]]}
         selected_config_data.update(config_temp_data)
         config_temp_data = {}
-    
+
     return selected_config_data
 
 def get_query_options():

--- a/monitor.py
+++ b/monitor.py
@@ -359,7 +359,6 @@ def get_node_status(spy_link):
     Returns:
         string: Node Status.
     '''
-    
     job_type,job_platform = job_classifier(spy_link)
     
     check_for_gather_libvirt_dir = check_if_gather_libvirt_dir_exists(spy_link,job_type)
@@ -371,7 +370,7 @@ def get_node_status(spy_link):
     
     node_log_url = PROW_VIEW_URL + spy_link[8:] + \
         "/artifacts/" + job_type +"/artifacts/oc_cmds/nodes"
-    
+ 
     try:
         node_log_response = requests.get(node_log_url, verify=False, timeout=15)
         if "NAME" in node_log_response.text:
@@ -380,7 +379,7 @@ def get_node_status(spy_link):
                 return "Some Nodes are in NotReady state"
             elif response_str.count("control-plane,master") != 3:
                 return "Not all master nodes are up and running"
-            elif (job_platform == "mce" and response_str.count("worker") != 3) or (job_platform != "mce" and response_str.count("worker-") != 2): 
+            elif ((job_platform == "mce" or "compact" in node_log_url ) and response_str.count("worker") != 3) or ((job_platform != "mce" and "compact" not in node_log_url) and response_str.count("worker-") != 2): 
                 return "Not all worker nodes are up and running"
         else:
             return "Node details not found"


### PR DESCRIPTION
Added changes to check worker node status of compact runs and  modified getting all CIs job history based on the comments

```$ python CI_JobHistory.py --job_type pa
Select the required ci's serial number with a space 25
Enter Before date (YYYY-MM-DD): 2024-02-17
Enter After date (YYYY-MM-DD): 2024-02-17
Please select one of the option from Job History functionalities:
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 3
Checking runs from 2024-02-17 to 2024-02-17
--------------------------------------------------------------------------------------------------
4.16 compact
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-compact-ovn-remote-libvirt-ppc64le/1758944472382574592
Nightly info- ppc64le-latest-registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.16.0-0.nightly-ppc64le-2024-02-17-180731
Lease Quota- libvirt-ppc64le-1-2
All nodes are in Ready state
No crash observed
Failed conformance testcases:
1. [sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
All monitor testcases passed
All symptom_detection testcases passed

$python CI_JobHistory.py --job_type p
Select the required ci's serial number with a space 23
Enter Before date (YYYY-MM-DD): 2024-04-12
Enter After date (YYYY-MM-DD): 2024-04-12
Please select one of the option from Job History functionalities:
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 3
Checking runs from 2024-04-12 to 2024-04-12
--------------------------------------------------------------------------------------------------
4.15 MCE
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-mce-power-conformance/1778664600854597632
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:980d8159ed554c3ac4fc6b081d849b927f1db5498ef7c1907b695775ef009e8f
Lease Quota- us-east-2--aws-quota-slice-00
All nodes are in Ready state

$python CI_JobHistory.py --job_type p
Select the required ci's serial number with a space 21
Enter Before date (YYYY-MM-DD): 2024-04-15
Enter After date (YYYY-MM-DD): 2024-04-15
Please select one of the option from Job History functionalities:
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 3
Checking runs from 2024-04-15 to 2024-04-15
--------------------------------------------------------------------------------------------------
4.16 heavy build
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-heavy-build-ovn-remote-libvirt-ppc64le/1779857536975900672
Nightly info- ppc64le-latest-registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.16.0-0.nightly-ppc64le-2024-04-15-071712
Lease Quota- libvirt-ppc64le-0-2
All nodes are in Ready state
No crash observed
Failed conformance testcases:
1. [sig-builds][Feature:Builds] prune builds based on settings in the buildconfig should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
All monitor testcases passed
All symptom_detection testcases passed


python CI_JobHistory.py --job_type z
1  4.11 libvirt
2  4.11 heavy build
3  4.12 libvirt
4  4.12 heavy build
5  4.13 libvirt
6  4.13 heavy build
7  4.14 libvirt
8  4.14 heavy build
9  4.15 libvirt
10  4.15 heavy build
11  All the above
Select the required ci's serial number with a space 11
Enter Before date (YYYY-MM-DD): 2024-04-17
Enter After date (YYYY-MM-DD): 2024-04-17
Please select one of the option from Job History functionalities:
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 2
Checking runs from 2024-04-17 to 2024-04-17
| Build            |         Prow Job ID | Install Status   | Lease             |
|:-----------------|--------------------:|:-----------------|:------------------|
| 4.11 heavy build | 1780401127527813120 | ERROR            | libvirt-s390x-6-1 |
| 4.12 heavy build | 1780401127527813120 | ERROR            | libvirt-s390x-6-1 |
| 4.13 libvirt     | 1780416215634677760 | ERROR            | libvirt-s390x-6-0 |
| 4.14 libvirt     | 1780431315871469568 | ERROR            | libvirt-s390x-3-0 |
| 4.15 libvirt     | 1780446451810177024 | ERROR            | libvirt-s390x-5-0 |

```