### PR TITLE
Added 4.17 CAPI Job

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -988,6 +988,7 @@ def get_jobs_with_date(prowci_url,start_date,end_date):
             td_element2 = str(td_element)
             next_link_pattern = r'/job[^>"]*'
             next_link_match = re.search(next_link_pattern,td_element2)
+            next_link = ''
             if next_link_match != None:
                 next_link = next_link_match.group()
 

--- a/p_periodic.json
+++ b/p_periodic.json
@@ -20,7 +20,7 @@
     "4.16 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le",
     "4.16 powervs": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-ppc64le-powervs-original",
     "4.16 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
-    "4.16 powervs capi": "periodic-ci-openshift-installer-master-altinfra-periodics-e2e-powervs-capi-ovn",
+    "4.17 powervs capi": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-ppc64le-powervs-capi",
     "4.14 MCE": "periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-mce-power-conformance",
     "4.15 MCE": "periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-mce-power-conformance",
     "4.16 MCE": "periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-mce-power-conformance",


### PR DESCRIPTION
Resolved Issue #65 

1. Added 4.17 capi job
2. Resolved a error "unbound variable next_link" by initializing it as empty string