### PR TITLE
Fix get brief job info to ensure it returns iterable object.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -1122,7 +1122,7 @@ def get_brief_job_info(build_list,prow_ci_name,zone=None):
     
     if isinstance(build_list,str):
         print(build_list)
-        return 1
+        return []
     summary_list = []   
     
     i=0

--- a/monitor.py
+++ b/monitor.py
@@ -371,16 +371,28 @@ def get_node_status(spy_link):
     
     node_log_url = PROW_VIEW_URL + spy_link[8:] + \
         "/artifacts/" + job_type +"/artifacts/oc_cmds/nodes"
+    
+    pattern=r"(\d+\.\d+)"
+    match=re.search(pattern,spy_link[8:])
+    version=float(match.group(1))
+    if "upgrade" in spy_link:
+        version=version-0.01
+    
  
     try:
         node_log_response = requests.get(node_log_url, verify=False, timeout=15)
         if "NAME" in node_log_response.text:
+            if version > 4.15 and job_platform == "libvirt":
+                workers="compute-"   
+            else:
+                workers="worker-"
+    
             response_str=node_log_response.text
             if "NotReady" in response_str:
                 return "Some Nodes are in NotReady state"
             elif response_str.count("control-plane,master") != 3:
                 return "Not all master nodes are up and running"
-            elif ((job_platform == "mce" or "compact" in node_log_url ) and response_str.count("worker") != 3) or ((job_platform != "mce" and "compact" not in node_log_url) and response_str.count("worker-") != 2): 
+            elif ((job_platform == "mce" or "compact" in node_log_url ) and response_str.count("worker") != 3) or ((job_platform != "mce" and "compact" not in node_log_url) and response_str.count(workers) != 2):
                 return "Not all worker nodes are up and running"
         else:
             return "Node details not found"
@@ -1098,7 +1110,7 @@ def get_next_page_first_build_date(ci_next_page_spylink,end_date):
 def get_brief_job_info(build_list,prow_ci_name,zone=None):
 
     """
-    Gets brief information of all the jobs.
+    Gets brief information of all the jobs
 
     Args:
         build_list: list of builds

--- a/p_periodic.json
+++ b/p_periodic.json
@@ -14,7 +14,6 @@
     "4.14 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
     "4.15 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-remote-libvirt-ppc64le",
     "4.15 powervs original": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-original",
-    "4.15 powervs siguid": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-e2e-ovn-ppc64le-powervs-siguid",
     "4.15 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
     "4.15 to 4.16 upgrade": "periodic-ci-openshift-multiarch-master-nightly-4.16-upgrade-from-nightly-4.15-ocp-ovn-remote-libvirt-ppc64le",
     "4.16 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le",


### PR DESCRIPTION
1. Fix(https://github.com/ocp-power-automation/ci-monitoring-automation/issues/63) change in the name of worker node from the build above 4.15 ,updated the get_node function .
2. Changed the return type of get_brief_job_info() function

```
| Job                  |       Prow Build ID | Install Status   | Lease               | Test result                |
|:---------------------|--------------------:|:-----------------|:--------------------|:---------------------------|
| 4.12 libvirt         | 1810826698459975680 | SUCCESS          | libvirt-ppc64le-1-0 | Failed to get Test summary |
| 4.13 libvirt         | 1810841604483715072 | ERROR            | libvirt-ppc64le-2-0 |                            |
| 4.14 libvirt         | 1810856662727135232 | ERROR            | libvirt-ppc64le-2-3 |                            |
| 4.15 libvirt         | 1810871808191107072 | ERROR            | libvirt-ppc64le-2-1 |                            |
| 4.15 to 4.16 upgrade | 1810867144435437568 | SUCCESS          | libvirt-ppc64le-0-1 | PASS                       |
| 4.15 to 4.16 upgrade | 1810839762123100160 | SUCCESS          | libvirt-ppc64le-0-2 | PASS                       |
| 4.16 libvirt         | 1810886951251742720 | ERROR            | libvirt-ppc64le-2-2 |                            |
| 4.16 libvirt         | 1810867144062144512 | SUCCESS          | libvirt-ppc64le-1-3 | Failed to get Test summary |
| 4.16 libvirt         | 1810839762173431808 | SUCCESS          | libvirt-ppc64le-1-2 | PASS                       |
 ``` 