### PR TITLE
added 4.17 job list

### DIFF
--- a/p_periodic.json
+++ b/p_periodic.json
@@ -19,9 +19,13 @@
     "4.16 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-remote-libvirt-ppc64le",
     "4.16 powervs": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-e2e-ovn-ppc64le-powervs-original",
     "4.16 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
-    "4.17 powervs capi": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-ppc64le-powervs-capi",
+    "4.16 to 4.17 upgrade":"periodic-ci-openshift-multiarch-master-nightly-4.17-upgrade-from-nightly-4.16-ocp-ovn-remote-libvirt-ppc64le",
+    "4.17 libvirt": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-ppc64le",
+    "4.17 powervs capi":"periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-powervs-capi-multi-p-p",
+    "4.17 powervs": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-powervs-original-multi-p-p",
+    "4.17 heavy build": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-ppc64le",
     "4.14 MCE": "periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-mce-power-conformance",
-    "4.15 MCE": "periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-mce-power-ovn-conformance",
-    "4.16 MCE": "periodic-ci-openshift-hypershift-release-4.16-periodics-e2e-mce-power-ovn-conformance",
+    "4.15 MCE": "periodic-ci-openshift-hypershift-release-4.15-periodics-mce-e2e-power-ovn-conformance",
+    "4.16 MCE": "periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-power-ovn-conformance",
     "4.14 SNO": "periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-e2e-sno-power"
 }


### PR DESCRIPTION
Added this jobs to be monitored.
1.  4.16 to 4.17 upgrade
2.   4.17 libvirt
3.   4.17 powervs
4.   4.17 heavy build

```
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.16 to 4.17 upgrade
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-upgrade-from-nightly-4.16-ocp-ovn-remote-libvirt-ppc64le/1820565683868536832
Nightly info- ppc64le-initial-registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.16.0-0.nightly-ppc64le-2024-08-05-184415 ppc64le-latest-registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-08-05-135103
Lease Quota- libvirt-ppc64le-2-2
Node details not found
No crash observed
Cluster Creation Failed
---------------------------------------------------------------------------------------------------
4.17 libvirt
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-ppc64le/1823104589193285632
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-08-12-210749
Lease Quota- libvirt-ppc64le-1-2
No crash observed
Build Passed
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.17 powervs
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-ppc64le-powervs-original/1820867682254196736
Nightly info- ppc64le-latest-registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-08-06-134056
Lease Quota- wdc06
No crash observed
Build Passed

4.17 heavy build
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-ppc64le/1823104589121982464
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-08-12-210749
Lease Quota- libvirt-ppc64le-1-3
No crash observed
Build Passed

--------------------------------------------------------------------------------------------------
 ```