### PR TITLE
fix nightly and lease details for multi

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -470,9 +470,6 @@ def get_nightly(build_log_url,build_log_response, job_platform):
         nightly_log_re = re.compile('(Resolved release {}-latest to (\S+))'.format(job_platform), re.MULTILINE|re.DOTALL)
         nightly_log_match = nightly_log_re.search(build_log_response.text)
         if nightly_log_match is None:
-            if job_platform == 'multi':
-                nightly = "Failed to fetch nightly image"
-            else:
                 rc_nightly_log_re = re.compile('(Using explicitly provided pull-spec for release {}-latest \((\S+)\))'.format(job_platform), re.MULTILINE|re.DOTALL)
                 rc_nightly_log_match = rc_nightly_log_re.search(build_log_response.text)
                 if rc_nightly_log_match is None:
@@ -536,6 +533,15 @@ def get_quota_and_nightly(spy_link):
             job_platform+="-s390x"
             lease = get_lease(build_log_response,job_platform )
             nightly = get_nightly(build_log_url,build_log_response, 's390x')
+        elif "multi" in spy_link:
+            if "powervs" in spy_link:
+                job_platform = "powervs"
+                job_platform+="-[1-9]"
+                lease=get_lease(build_log_response,job_platform)
+            else:
+                job_platform="multi"
+                lease=get_lease(build_log_response,'libvirt-ppc64le')
+            nightly = get_nightly(build_log_url,build_log_response, "multi") 
 
         elif "mce" in spy_link:
             job_platform = "aws"


### PR DESCRIPTION
```--------------------------------------------------------------------------------------------------
4.17 heavy build multi
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-p-p/1835096451529576448
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2024-09-14-231656
Lease Quota- libvirt-ppc64le-0-1
No crash observed
Build Passed


2 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-p-p/1835068164094824448
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2024-09-14-212434
Lease Quota- libvirt-ppc64le-0-1
No crash observed
Build Passed


3 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-multi-p-p/1835037204750012416
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2024-09-14-192043
Lease Quota- libvirt-ppc64le-1-3
No crash observed
Build Passed
```