### PR TITLE
changed name of job_platform flag

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -145,7 +145,7 @@ def get_testcase_failure(spylinks, zone, tc_name):
     print("--------------------------------------------------------------------------------------------------")
     print("\n")
 
-def display_ci_links(config_data,job_platform):
+def display_ci_links(config_data,filter):
 
     '''
     Gets selected CI input.
@@ -165,11 +165,11 @@ def display_ci_links(config_data,job_platform):
 
     if JENKINS == "False":
         for ci_name in config_data.keys():
-            if job_platform[0]=='All':
+            if filter[0]=='All':
                 j=j+1
                 ci_name_list.append(ci_name)
                 print(j,"",ci_name)
-            elif any(w in ci_name for w in job_platform):
+            elif any(w in ci_name for w in filter):
                 j=j+1
                 ci_name_list.append(ci_name)
                 print(j,"",ci_name)
@@ -248,9 +248,9 @@ def main():
     parser = argparse.ArgumentParser(description='Get the job history')
     parser.add_argument('--zone', help='specify the lease/zone', type= lambda arg:arg.split(','))
     parser.add_argument('--job_type', default='p', choices=['p','z','pa'], help= 'Specify the CI job type (Power(p) or s390x(z) or Power Auxillary(pa)), default is p')
-    parser.add_argument('--job_platform',default='All',type= lambda arg:arg.split(','), help='Specify the job_platform to fetch jobs, supported values are heavy build / libvirt / powervs / upgrade')
+    parser.add_argument('--filter',default='All',type= lambda arg:arg.split(','), help='Specify the filter string to fetch jobs (Example heavy build / libvirt / powervs / upgrade / 4.14 / 4.15 / 4.16 / 4.17/ 4.18 )')
     args = parser.parse_args()
-    job_platform=args.job_platform
+    filter=args.filter
 
     if args.job_type == 'p':
         config_file = 'p_periodic.json'
@@ -262,7 +262,7 @@ def main():
     monitor.PROW_URL = monitor.set_prow_url(args.job_type)
     config_data = monitor.load_config(config_file)
 
-    ci_list = display_ci_links(config_data,job_platform)
+    ci_list = display_ci_links(config_data,filter)
     if isinstance(ci_list,dict):
         start_date,end_date = get_date_input()
         if start_date != None and end_date != None:


### PR DESCRIPTION
fixes #89 
Updated the job_platform name to "filter"
``` 
PS C:\Users\AlokGoswami\project\ci-monitoring-automation> python3 .\CI_JobHistory.py --filter 4.17
1  4.16 to 4.17 upgrade
2  4.17 libvirt
3  4.17 libvirt multi
4  4.17 powervs capi
5  4.17 heavy build multi
6  4.17 heavy build
7  4.17 to 4.18 upgrade
8  4.17 MCE
9  All the above
Select the required ci's serial number with a space 9 
Enter Before date (YYYY-MM-DD): 2024-12-11
Enter After date (YYYY-MM-DD): 2024-12-11
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
Enter the option: 3
Checking runs from 2024-12-11 to 2024-12-11
--------------------------------------------------------------------------------------------------
4.17 libvirt
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-ppc64le/1866645771760177152
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-12-11-004258
Lease Quota- libvirt-ppc64le-0-1
No crash observed
Build Passed



1/1 deploys succeeded
1/1 e2e tests succeeded
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.17 heavy build
1 Job link: https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-heavy-build-ovn-remote-libvirt-ppc64le/1866645771806314496
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.17.0-0.nightly-ppc64le-2024-12-11-004258
Lease Quota- libvirt-ppc64le-1-0
No crash observed
Build Passed



1/1 deploys succeeded
1/1 e2e tests succeeded
--------------------------------------------------------------------------------------------------```