### PR TITLE
Fix for daily build update

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -129,10 +129,10 @@ def get_jobs(prow_link):
                 if match:
                     all_jobs=match.group(1)
                     all_jobs_parsed=json.loads(all_jobs)
-                    current_date=get_current_date()
+                    current_date=get_current_date().date()
                     jobs_run_today = []
                     for ele in all_jobs_parsed:
-                        job_time=parse_job_date(ele["Started"])
+                        job_time=parse_job_date(ele["Started"]).date()
                         if job_time == current_date and ele["Result"] != "PENDING":
                             job_log_path = ele["SpyglassLink"]
                             jobs_run_today.append(job_log_path)


### PR DESCRIPTION
As for the daily build update scripts we only need the date to be considered. Have modified job_time and current_time to dates instead of time.
```
| Job                    |       Prow Build ID | Install Status   | Lease                         | Test result        |
|:-----------------------|--------------------:|:-----------------|:------------------------------|:-------------------|
| 4.17 libvirt           | 1869973755564920832 | ERROR            | libvirt-ppc64le-0-0           |                    |
| 4.17 libvirt multi     | 1869976673999392768 | ERROR            | libvirt-ppc64le-0-1           |                    |
| 4.17 powervs capi      | 1870031476653821952 | FAILURE          | lon06-powervs-7-quota-slice-2 |                    |
| 4.17 heavy build multi | 1869976674037141504 | SUCCESS          | libvirt-ppc64le-1-1           | PASS               |
| 4.17 heavy build       | 1869973755619446784 | SUCCESS          | libvirt-ppc64le-1-0           | PASS               |
| 4.18 libvirt           | 1870002784460345344 | SUCCESS          | libvirt-ppc64le-1-2           | PASS               |
| 4.18 libvirt           | 1869912630886404096 | SUCCESS          | libvirt-ppc64le-2-1           | PASS               |
| 4.18 libvirt multi     | 1869916013307367424 | SUCCESS          | libvirt-ppc64le-2-3           | 1 testcases failed |
| 4.18 powervs capi      | 1870016449045598208 | FAILURE          | lon06-powervs-7-quota-slice-0 |                    |
| 4.18 heavy build       | 1870002784548425728 | SUCCESS          | libvirt-ppc64le-2-1           | 1 testcases failed |
| 4.18 heavy build       | 1869912633402986496 | ERROR            | libvirt-ppc64le-0-2           |                    |
| 4.18 heavy build multi | 1869915985666904064 | SUCCESS          | libvirt-ppc64le-1-2           | PASS               |
| 4.19 libvirt           | 1869983170548469760 | SUCCESS          | libvirt-ppc64le-2-0           | 1 testcases failed |
| 4.19 libvirt multi     | 1869985272666525696 | SUCCESS          | libvirt-ppc64le-2-2           | PASS               |
| 4.19 heavy build       | 1869983170586218496 | SUCCESS          | libvirt-ppc64le-1-3           | 1 testcases failed |
| 4.19 heavy build multi | 1869985303284944896 | ERROR            | libvirt-ppc64le-0-2           |                    |
| 4.15 MCE               | 1869986184223002624 | SUCCESS          | us-east-1--aws-quota-slice-27 | PASS               |
| 4.16 MCE               | 1869986186873802752 | SUCCESS          | us-east-2--aws-quota-slice-34 | PASS               |
```