### PR TITLE
Added check to verify hypervisor error

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,3 +1,4 @@
 PROW_VIEW_URL = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
 JOB_LINK_URL= "https://prow.ci.openshift.org/"
 RELEASE_URL = "https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4-stable-ppc64le/release/"
+HYPERVISOR_CONNECTION_ERROR = "failed to connect to the hypervisor"


### PR DESCRIPTION
Fix: https://github.com/ocp-power-automation/ci-monitoring-automation/issues/86
**With fix:**
```
Select the required ci's serial number with a space 16
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
7. Get build based on release 
Enter the option: 3
Enter Before date (YYYY-MM-DD): 2025-01-25
Enter After date (YYYY-MM-DD): 2025-01-24
Checking runs from 2025-01-24 00:00:00 to 2025-01-25 00:00:00
--------------------------------------------------------------------------------------------------
4.17 libvirt multi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-multi-p-p/1882880284907540480
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2025-01-24-194228
Lease Quota- libvirt-ppc64le-2-1
All nodes are in Ready state
No crash observed
Cluster Creation Failed


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-multi-p-p/1882786782232186880
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2025-01-24-132918
Lease Quota- libvirt-ppc64le-1-2
Node details not found
Cluster Creation Failed.failed to connect to the hypervisor


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-multi-p-p/1882678744884187136
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2025-01-24-062142
Lease Quota- libvirt-ppc64le-1-3
Node details not found
Cluster Creation Failed.failed to connect to the hypervisor



0/3 deploys succeeded
0/3 e2e tests succeeded
--------------------------------------------------------------------------------------------------

```
**Brief summary**
```
Enter the option: 2
Enter Before date (YYYY-MM-DD): 2025-02-07
Enter After date (YYYY-MM-DD): 2025-02-05
Checking runs from 2025-02-05 00:00:00 to 2025-02-07 00:00:00


| Job          |       Prow Build ID | Install Status   | Lease               | Test result                         |
|:-------------|--------------------:|:-----------------|:--------------------|:------------------------------------|
| 4.18 libvirt | 1887622535147687936 | ERROR            | libvirt-ppc64le-1-1 | failed to connect to the hypervisor |
| 4.18 libvirt | 1887581093142466560 | FAILURE          | libvirt-ppc64le-0-2 |                                     |
| 4.18 libvirt | 1887460260105424896 | SUCCESS          | libvirt-ppc64le-2-2 | 3 testcases failed                  |
| 4.18 libvirt | 1887369646265339904 | SUCCESS          | libvirt-ppc64le-2-0 | 2 testcases failed                  |
| 4.18 libvirt | 1887279029875118080 | FAILURE          | libvirt-ppc64le-0-2 |                                     |
| 4.18 libvirt | 1887188527850983424 | SUCCESS          | libvirt-ppc64le-1-2 | 3 testcases failed                  |
| 4.18 libvirt | 1887097961100349440 | SUCCESS          | libvirt-ppc64le-2-2 | 3 testcases failed                  |
| 4.18 libvirt | 1887007407599521792 | FAILURE          | libvirt-ppc64le-0-0 |                                     |

```
**Without fix:**
```
Select the required ci's serial number with a space 16
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
7. Get build based on release 
Enter the option: 3    
Enter Before date (YYYY-MM-DD): 2024-12-21
Enter After date (YYYY-MM-DD): 2024-12-20
Checking runs from 2024-12-20 00:00:00 to 2024-12-21 00:00:00
--------------------------------------------------------------------------------------------------
4.17 libvirt multi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-ovn-remote-libvirt-multi-p-p/1869976673999392768
Nightly info- registry.ci.openshift.org/ocp-multi/4.17-art-latest-multi:4.17.0-0.nightly-multi-2024-12-20-050559
Lease Quota- libvirt-ppc64le-0-1
Node details not found
No crash observed
Unable to get cluster status please check prowCI UI 

0/1 deploys succeeded
0/1 e2e tests succeeded

```
**Brief summary**
```
| Job          |       Prow Build ID | Install Status   | Lease               | Test result        |
|:-------------|--------------------:|:-----------------|:--------------------|:-------------------|
| 4.18 libvirt | 1887622535147687936 | ERROR            | libvirt-ppc64le-1-1 |                    |
| 4.18 libvirt | 1887581093142466560 | FAILURE          | libvirt-ppc64le-0-2 |                    |
| 4.18 libvirt | 1887460260105424896 | SUCCESS          | libvirt-ppc64le-2-2 | 3 testcases failed |
| 4.18 libvirt | 1887369646265339904 | SUCCESS          | libvirt-ppc64le-2-0 | 2 testcases failed |
| 4.18 libvirt | 1887279029875118080 | FAILURE          | libvirt-ppc64le-0-2 |                    |
| 4.18 libvirt | 1887188527850983424 | SUCCESS          | libvirt-ppc64le-1-2 | 3 testcases failed |
| 4.18 libvirt | 1887097961100349440 | SUCCESS          | libvirt-ppc64le-2-2 | 3 testcases failed |
| 4.18 libvirt | 1887007407599521792 | FAILURE          | libvirt-ppc64le-0-0 |                    |
```