### PR TITLE
Added check to handle invalid release.

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -31,7 +31,8 @@ def fetch_release_date(release):
                         break
              return start_date
         else:
-            return "failed to get the release page"
+            print(f"Failed to get the release page.  {response.text}")
+            sys.exit(1)
     except requests.Timeout as e:
         return "Request timed out"
     except requests.RequestException as e:


### PR DESCRIPTION
FIx https://github.com/ocp-power-automation/ci-monitoring-automation/issues/96

```
(env) keerthanaarumugam@Keerthanas-MacBook-Pro ci-monitoring-automation % python CI_JobHistory.py
1  4.13 to 4.14 upgrade
2  4.14 libvirt
3  4.14 powervs
4  4.14 to 4.15 upgrade
5  4.14 heavy build
6  4.15 libvirt
7  4.15 powervs original
8  4.15 heavy build
9  4.15 to 4.16 upgrade
10  4.16 libvirt
.
.
.
Select the required ci's serial number with a space 6
Please select one of the option from Job History functionalities: 
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
7. Get build based on release 
Enter the option: 7
Enter the release: 4.15.45
Enter the next release (provide latest if no next release): latest
Failed to get the release page.  unable to find release tag 4.15.45, it may have been deleted

```