### PR TITLE
added 4.18 MCE job

### DIFF
--- a/p_auxillary.json
+++ b/p_auxillary.json
@@ -10,7 +10,7 @@
     "4.16 jenkins": "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-jenkins-e2e-ovn-remote-libvirt-ppc64le",
     "4.17 jenkins": "periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-jenkins-e2e-ovn-remote-libvirt-multi-p-p",
     "4.18 jenkins": "periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-jenkins-e2e-ovn-remote-libvirt-multi-p-p",
-    "4.19 jenkins": "periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-jenkins-e2e-ovn-remote-libvirt-multi-p-p",
+    "4.19 jenkins": "periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-jenkins-e2e-ovn-remote-libvirt-multi-p-p",
     "4.14 fips":  "periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-fips-ovn-remote-libvirt-ppc64le",
     "4.15 fips":  "periodic-ci-openshift-multiarch-master-nightly-4.15-ocp-fips-ovn-remote-libvirt-ppc64le",
     "4.16 fips":  "periodic-ci-openshift-multiarch-master-nightly-4.16-ocp-fips-ovn-remote-libvirt-ppc64le",

--- a/p_periodic.json
+++ b/p_periodic.json
@@ -37,5 +37,6 @@
     "4.15 MCE": "periodic-ci-openshift-hypershift-release-4.15-periodics-mce-e2e-power-ovn-conformance",
     "4.16 MCE": "periodic-ci-openshift-hypershift-release-4.16-periodics-mce-e2e-power-ovn-conformance",
     "4.17 MCE": "periodic-ci-openshift-hypershift-release-4.17-periodics-mce-e2e-power-ovn-conformance",
+    "4.18 MCE": "periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-power-ovn-conformance",
     "4.14 SNO": "periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-e2e-sno-power"
 }


### PR DESCRIPTION
```--------------------------------------------------------------------------------------------------
4.18 MCE
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.18-periodics-mce-e2e-power-ovn-conformance/1884149537338036224
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:3acd3b00319f197cd13cb8c4582ec495f9e21198e05bde6de08e73192807f1a7
Lease Quota- us-west-1--aws-quota-slice-22
All nodes are in Ready state
20 testcases have failed, please refer to the job link for more information
```