### PR TITLE
Add support to fetch a single success job by setting a flag

### DIFF
--- a/CI_JobHistory.py
+++ b/CI_JobHistory.py
@@ -317,6 +317,7 @@ def main():
     parser.add_argument('--job_type', default='p', choices=['p','z','pa'], help= 'Specify the CI job type (Power(p) or s390x(z) or Power Auxillary(pa)), default is p')
     parser.add_argument('--filter',default='All',type= lambda arg:arg.split(','), help='Specify the filter string to fetch jobs (Example heavy build / libvirt / powervs / upgrade / 4.14 / 4.15 / 4.16 / 4.17/ 4.18 )')
     parser.add_argument('--job_install_status',default='All',choices=['failure','success'],help='Specify the desired job install status to filter the jobs accordingly')
+    parser.add_argument('--fetch_one_success_job',action='store_true', help='Set this flag to check job runs until one success job is found')
     args = parser.parse_args()
     filter=args.filter
 
@@ -420,7 +421,7 @@ def main():
             if option == '7':
                 for ci_name,ci_link in ci_list.items():
                     spy_links = monitor.get_jobs_with_date(ci_link,start_date,end_date)
-                    monitor.get_detailed_job_info(spy_links,ci_name,zone=args.zone)
+                    monitor.get_detailed_job_info(spy_links,ci_name,zone=args.zone,fetch_one_success_job=args.fetch_one_success_job)
                     monitor.final_job_list = []
 
 if __name__ == "__main__":

--- a/monitor.py
+++ b/monitor.py
@@ -1143,7 +1143,6 @@ def get_jobs_with_date(prowci_url,start_date,end_date):
                         if end_date <= job_time <= start_date and ele["Result"] != "PENDING" :
                             job_log_path = ele["SpyglassLink"]
                             final_job_list.append(job_log_path)
-
                     #build match extracts the next page spylink
                     build_regex = r"/([^/?]+)\?.+"
                     build_match = re.search(build_regex,next_link)
@@ -1296,7 +1295,8 @@ def get_brief_job_info(build_list,prow_ci_name,zone=None,job_filter='All'):
         summary_list.append(job_dict)
     return summary_list
 
-def get_detailed_job_info(build_list, prow_ci_name, zone=None, job_filter="all"):
+def get_detailed_job_info(build_list,prow_ci_name,zone=None,fetch_one_success_job=False, job_filter="all"):
+
     """
     Prints detailed information of all the jobs.
 
@@ -1358,7 +1358,9 @@ def get_detailed_job_info(build_list, prow_ci_name, zone=None, job_filter="all")
                 print("Lease Quota-", lease)
             check_node_crash(build)
             print("Build Passed")
-
+            if  fetch_one_success_job == True:
+                print("Found a passed job, hence ignoring subsequent jobs")
+                break
         elif build_status == 'FAILURE':
             if "sno" not in build:
                 print("Lease Quota-", lease)    


### PR DESCRIPTION
This change is useful when you have to find a success job in a particular release to qualify that the release image is proper. Hence adding a new flag to support fetching one success job and ignoring all others

```
shilpagokul@Shilpas-MacBook-Pro ci-monitoring-automation % python3 CI_JobHistory.py -h
usage: CI_JobHistory.py [-h] [--zone ZONE] [--job_type {p,z,pa}] [--filter FILTER] [--fetch_one_success_job]

Get the job history

options:
  -h, --help            show this help message and exit
  --zone ZONE           specify the lease/zone
  --job_type {p,z,pa}   Specify the CI job type (Power(p) or s390x(z) or Power Auxillary(pa)), default is p
  --filter FILTER       Specify the filter string to fetch jobs (Example heavy build / libvirt / powervs / upgrade / 4.14 / 4.15 / 4.16 / 4.17/ 4.18 )
  --fetch_one_success_job
                        Set this flag to check job runs until one success job is found
shilpagokul@Shilpas-MacBook-Pro ci-monitoring-automation %
```

```
shilpagokul@Shilpas-MacBook-Pro ci-monitoring-automation % python3 CI_JobHistory.py --filter 4.18 --fetch_one_success_job
1  4.17 to 4.18 upgrade
2  4.18 libvirt
3  4.18 libvirt multi
4  4.18 powervs capi
5  4.18 heavy build
6  4.18 heavy build multi
7  4.18 agent
8  4.18 to 4.19 upgrade
9  All the above
Select the required ci's serial number with a space 2
Please select one of the option from Job History functionalities:
1. Check Node Crash
2. Brief Job information
3. Detailed Job information
4. Failed testcases
5. Get builds with testcase failure
6. Get testcase failure frequency
7. Get build based on release
Enter the option: 7
Enter the release: 4.18.0-rc.8
Enter the next release (provide latest if no next release): latest
Checking runs from 2025-02-06 19:47:41 to 2025-02-12 13:34:11.501246
--------------------------------------------------------------------------------------------------
4.18 libvirt
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-e2e-ovn-remote-libvirt-ppc64le/1889320486635048960
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.18.0-0.nightly-ppc64le-2025-02-11-142433
Lease Quota- libvirt-ppc64le-2-0
All nodes are in Ready state
No crash observed
All conformance testcases passed
Failed monitor testcases:
1. API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients
All symptom_detection testcases passed


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-e2e-ovn-remote-libvirt-ppc64le/1889229981142224896
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.18.0-0.nightly-ppc64le-2025-02-11-082433
Lease Quota- libvirt-ppc64le-1-2
All nodes are in Ready state
No crash observed
ERROR


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-e2e-ovn-remote-libvirt-ppc64le/1889138935813115904
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.18.0-0.nightly-ppc64le-2025-02-11-022433
Lease Quota- libvirt-ppc64le-1-2
No crash observed
Build Passed
Found a passed job, hence ignoring subsequent jobs

3/13 deploys succeeded
1/13 e2e tests succeeded
--------------------------------------------------------------------------------------------------
shilpagokul@Shilpas-MacBook-Pro ci-monitoring-automation %
```