### PR TITLE
Added fix for the issue in  fetching release info for 4.19 releases

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,4 +1,5 @@
 PROW_VIEW_URL = "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs"
 JOB_LINK_URL= "https://prow.ci.openshift.org/"
-RELEASE_URL = "https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4-stable-ppc64le/release/"
+STABLE_RELEASE_URL = "https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4-stable-ppc64le/release/"
+DEV_PREVIEW_RELEASE_URL = "https://ppc64le.ocp.releases.ci.openshift.org/releasestream/4-dev-preview-ppc64le/release/"
 HYPERVISOR_CONNECTION_ERROR = "failed to connect to the hypervisor"

--- a/monitor.py
+++ b/monitor.py
@@ -17,20 +17,27 @@ def fetch_release_date(release):
     '''
     Returns the created date of release
     '''
-    url = constants.RELEASE_URL + release
+
     try:
+        url = constants.STABLE_RELEASE_URL + release
         response = requests.get(url, verify=False, timeout=15)
+        if response.status_code == 404:
+            url = constants.DEV_PREVIEW_RELEASE_URL + release
+            response = requests.get(url, verify=False, timeout=15)
+            if response.status_code == 404:
+                print(f"Failed to get the release page.  {response.text}")
+                sys.exit(1)
         if response.status_code == 200:
-             soup = BeautifulSoup(response.text, 'html.parser')
-             p_elements = soup.find_all("p")
-             for p in p_elements:
+            soup = BeautifulSoup(response.text, 'html.parser')
+            p_elements = soup.find_all("p")
+            for p in p_elements:
                 p_ele = p.string
                 if p_ele:
                     if "Created:" in p_ele:
                         start_date = p_ele.split(" ")[1]+" "+p_ele.split(" ")[2]
                         break
-             return start_date
-        else:
+            return start_date
+        else: 
             print(f"Failed to get the release page.  {response.text}")
             sys.exit(1)
     except requests.Timeout as e:


### PR DESCRIPTION
**Without fix**

```
7. Get build based on release
Enter the option: 7
Enter the release: 4.19.0-ec.1
Enter the next release (provide latest if no next release): 4.19.0-ec.2
Failed to get the release page.  release tag 4.19.0-ec.1 does not belong to release 4-stable-ppc64le

shilpagokul@Shilpas-MacBook-Pro ci-monitoring-automation %
```

**With fix**

```
Enter the option: 7
Enter the release: 4.19.0-ec.2
Enter the next release (provide latest if no next release): latest
Checking runs from 2025-02-17 18:27:05 to 2025-02-21 11:24:16.389237
--------------------------------------------------------------------------------------------------
4.19 powervs capi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1892711110436458496
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:a87d08bdd85cc1a1d1b9c8b41dc0c683bb0db32eb599434a7a71d801c9c2e2d7
Lease Quota- lon06-powervs-7-quota-slice-3
Node details not found
No crash observed
Cluster Creation Failed


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1892529875487559680
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:a87d08bdd85cc1a1d1b9c8b41dc0c683bb0db32eb599434a7a71d801c9c2e2d7
Lease Quota- lon06-powervs-7-quota-slice-3
Node details not found
No crash observed
Cluster Creation Failed


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1892348693445611520
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:666e157b02cb001e9193022fdb5774b3dd025ee246146462cb7bf2b168c88069
Lease Quota- lon06-powervs-7-quota-slice-3
Node details not found
No crash observed
Cluster Creation Failed


4 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1892167356281524224
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:0173ec61653397a294334d61051e1c7afc38ae8e45569a31706e40082668d6c5
Lease Quota- lon06-powervs-7-quota-slice-3
Node details not found
No crash observed
Cluster Creation Failed


5 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1891986142635495424
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:6c0f4e0539b52a6d8b677238cadc565559393a0bd9abd8dab1a056b59e373bee
Lease Quota- lon06-powervs-7-quota-slice-3
Node details not found
No crash observed
Cluster Creation Failed


6 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1891804997780246528
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:1f5fe253f4c998e764f1873f0790e087934ba80080198282c4dbaa68941111aa
Lease Quota- lon06-powervs-7-quota-slice-0
Node details not found
No crash observed
Cluster Creation Failed


7 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-ovn-powervs-capi-multi-p-p/1891623801930649600
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:bfc332a118b9b71c28fee372d304846ff2411e103dbbb3431d1c724751f0d157
Lease Quota- lon06-powervs-7-quota-slice-2
Node details not found
No crash observed
Cluster Creation Failed



0/7 deploys succeeded
0/7 e2e tests succeeded


Enter the option: 7
Enter the release: 4.18.1
Enter the next release (provide latest if no next release): latest
Checking runs from 2025-02-20 19:03:29 to 2025-02-21 11:28:39.202599
--------------------------------------------------------------------------------------------------
4.18 powervs capi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.18-ocp-e2e-ovn-powervs-capi-multi-p-p/1892665836204724224
Nightly info- multi-latest-quay.io/openshift-release-dev/ocp-release-nightly@sha256:56df499d479116349e40d615b385d3b94b1e7e7b83b993999dd9c3f9f7cd04c2
Lease Quota- lon06-powervs-7-quota-slice-2
All nodes are in Ready state

No crash observed
All conformance testcases passed
Failed monitor testcases: 
1. [Jira:"Networking / router"] monitor test service-type-load-balancer-availability setup
All symptom_detection testcases passed



1/1 deploys succeeded
0/1 e2e tests succeeded
--------------------------------------------------------------------------------------------------



```
