### PR TITLE
changed job_platform_string

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -578,7 +578,7 @@ def get_quota_and_nightly(spy_link):
         build_log_response = requests.get(build_log_url, verify=False, timeout=15)
         if 'ppc64le' in spy_link:      
             if job_platform == "libvirt":
-                job_platform+="-ppc64le"
+                job_platform+="-ppc64le-s2s"
             elif job_platform == "powervs":
                 job_platform+="-[1-9]"
             lease = get_lease(build_log_response,job_platform)
@@ -595,7 +595,7 @@ def get_quota_and_nightly(spy_link):
                 lease=get_lease(build_log_response,job_platform)
             else:
                 job_platform="multi"
-                lease=get_lease(build_log_response,'libvirt-ppc64le')
+                lease=get_lease(build_log_response,'libvirt-ppc64le-s2s')
             nightly = get_nightly(build_log_url,build_log_response, "multi") 
 
         elif "mce" in spy_link:


### PR DESCRIPTION
```
--------------------------------------------------------------------------------------------------
4.20 libvirt
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le/1967353061458317312
Build start time: 2025-09-15 03:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-221845
Lease Quota- libvirt-ppc64le-s2s-1-0
All nodes are in Ready state
No crash observed
13 testcases have failed, please refer to the job link for more information


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le/1967262435022737408
Build start time: 2025-09-14 21:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-161845
Lease Quota- libvirt-ppc64le-s2s-0-0
All nodes are in Ready state
No crash observed
8 testcases have failed, please refer to the job link for more information


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le/1967171801184210944
Build start time: 2025-09-14 15:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-101845
Lease Quota- libvirt-ppc64le-s2s-0-2
All nodes are in Ready state
No crash observed
7 testcases have failed, please refer to the job link for more information


4 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-ppc64le/1967081280042438656
Build start time: 2025-09-14 09:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-041845
Lease Quota- libvirt-ppc64le-s2s-1-3
All nodes are in Ready state
No crash observed
11 testcases have failed, please refer to the job link for more information



4/4 deploys succeeded
0/4 e2e tests succeeded
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.20 libvirt multi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-multi-p-p/1967303261715173376
Build start time: 2025-09-15 00:33
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- libvirt-ppc64le-s2s-0-0
All nodes are in Ready state
No crash observed
9 testcases have failed, please refer to the job link for more information


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-multi-p-p/1967210562383253504
Build start time: 2025-09-14 18:25
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- libvirt-ppc64le-s2s-0-0
All nodes are in Ready state
No crash observed
10 testcases have failed, please refer to the job link for more information


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-remote-s2s-libvirt-multi-p-p/1967115599138000896
Build start time: 2025-09-14 12:08
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- libvirt-ppc64le-s2s-1-2
All nodes are in Ready state
No crash observed
13 testcases have failed, please refer to the job link for more information



3/3 deploys succeeded
0/3 e2e tests succeeded
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.20 powervs capi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-powervs-capi-multi-p-p/1967211932788199424
Build start time: 2025-09-14 18:30
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- lon06-powervs-7-quota-slice-0
All nodes are in Ready state
No crash observed
15 testcases have failed, please refer to the job link for more information


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-e2e-ovn-powervs-capi-multi-p-p/1967030761085210624
Build start time: 2025-09-14 06:30
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- lon06-powervs-7-quota-slice-0
All nodes are in Ready state
No crash observed
Failed conformance testcases: 
1. [sig-api-machinery] ResourceQuota should verify ResourceQuota with terminating scopes through scope selectors. [Suite:openshift/conformance/parallel] [Suite:k8s]
All monitor testcases passed
All symptom_detection testcases passed



2/2 deploys succeeded
0/2 e2e tests succeeded
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.20 heavy build
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-ppc64le/1967353061462511616
Build start time: 2025-09-15 03:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-221845
Lease Quota- libvirt-ppc64le-s2s-0-3
No crash observed
Build Passed


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-ppc64le/1967262435068874752
Build start time: 2025-09-14 21:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-161845
Lease Quota- libvirt-ppc64le-s2s-1-0
No crash observed
Build Passed


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-ppc64le/1967171801289068544
Build start time: 2025-09-14 15:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-101845
Lease Quota- libvirt-ppc64le-s2s-1-2
No crash observed
Build Passed


4 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-ppc64le/1967081280197627904
Build start time: 2025-09-14 09:51
Nightly info- registry.ci.openshift.org/ocp-ppc64le/release-ppc64le:4.20.0-0.nightly-ppc64le-2025-09-14-041845
Lease Quota- libvirt-ppc64le-s2s-0-2
No crash observed
Build Passed



4/4 deploys succeeded
4/4 e2e tests succeeded
--------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------------------------
4.20 heavy build multi
1 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-multi-p-p/1967303246523404288
Build start time: 2025-09-15 00:33
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- Failed to fetch lease information
Node details not found
No crash observed
Unable to get cluster status please check prowCI UI 


2 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-multi-p-p/1967210596789129216
Build start time: 2025-09-14 18:25
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- libvirt-ppc64le-s2s-0-3
No crash observed
Build Passed


3 Job link:https://prow.ci.openshift.org//view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.20-ocp-heavy-build-ovn-remote-s2s-libvirt-multi-p-p/1967115599268024320
Build start time: 2025-09-14 12:08
Nightly info- quay.io/openshift-release-dev/ocp-release-nightly@sha256:34d9faf1f8b7b9a6d3aedd6c303a69a40fc1869eb14b52ea160671441a181014
Lease Quota- libvirt-ppc64le-s2s-0-0
All nodes are in Ready state
No crash observed
All conformance testcases passed
Failed monitor testcases: 
1. [sig-api-machinery][Feature:APIServer] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients
All symptom_detection testcases passed



2/3 deploys succeeded
1/3 e2e tests succeeded
-------------------------------------------------------------------------------------------------- ```